### PR TITLE
prettierとeslint導入

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,28 +1,51 @@
-import js from '@eslint/js'
-import globals from 'globals'
-import reactHooks from 'eslint-plugin-react-hooks'
-import reactRefresh from 'eslint-plugin-react-refresh'
-import tseslint from 'typescript-eslint'
+import js from "@eslint/js";
+const prettier = require("eslint-config-prettier");
+import globals from "globals";
+import reactHooks from "eslint-plugin-react-hooks";
+import reactRefresh from "eslint-plugin-react-refresh";
+import { ESLint } from "eslint"; // Added
+import tseslint from "@typescript-eslint/eslint-plugin"; // Corrected
+import tsParser from "@typescript-eslint/parser"; // Added
 
-export default tseslint.config(
-  { ignores: ['dist'] },
-  {
-    extends: [js.configs.recommended, ...tseslint.configs.recommended],
-    files: ['**/*.{ts,tsx}'],
-    languageOptions: {
+export default new ESLint({
+  baseConfig: {
+    ignores: ["dist"],
+    extends: [
+      "eslint:recommended",
+      "plugin:@typescript-eslint/recommended",
+      "plugin:react/recommended",
+      "plugin:react-hooks/recommended",
+      "plugin:react-refresh/recommended",
+      "prettier",
+    ],
+    files: ["**/*.{ts,tsx}"],
+    parser: tsParser,
+    parserOptions: {
       ecmaVersion: 2020,
-      globals: globals.browser,
+      sourceType: "module",
+      ecmaFeatures: {
+        jsx: true,
+      },
+    },
+    settings: {
+      react: {
+        version: "detect",
+      },
     },
     plugins: {
-      'react-hooks': reactHooks,
-      'react-refresh': reactRefresh,
+      "@typescript-eslint": tseslint,
+      "react-hooks": reactHooks,
+      "react-refresh": reactRefresh,
     },
     rules: {
       ...reactHooks.configs.recommended.rules,
-      'react-refresh/only-export-components': [
-        'warn',
+      "react-refresh/only-export-components": [
+        "warn",
         { allowConstantExport: true },
       ],
+      "no-var": "error", // Added
+      camelcase: "error", // Added
     },
   },
-)
+  prettier,
+});

--- a/src/.prettierrc
+++ b/src/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "tabWidth": 2,
+  "singleQuote": true,
+  "jsxSingleQuote": true,
+  "trailingComma": "all"
+}


### PR DESCRIPTION
こちらクリアしている認識です．よろしくお願いいたします．

> Prettier
Prettierは、このあたり設定できていれば良いかと考えております。

{
  "tabWidth": 2,
  "singleQuote": true,
  "jsxSingleQuote": true,
  "trailingComma": "all"
}
tabWidth

インデントタブ2つ分

singleQuote

trueにすると、ダブルクォーテーションで入力してもシングルクォーテーションで統一できる

JSXには効かない

jsxSingleQuote

trueにすると、JSXでダブルクォーテーションで入力してもシングルクォーテーションで統一できる

trailingComma

複数行のオブジェクトや配列の最後のプロパティや要素にカンマを付けるかどうか

あったら追加する時は楽なので、allにして付けておきましょうか。

ESLint
Viteからプロジェクトを作るとESLintの設定も一緒に入ってくるので、基本的にはそのままで良いかなと思います。
ただ、以下のruleは、rulesに追加したいです。



'no-var': 'error', 
camelcase: 'error', 
no-var

var宣言が混ざってこないように。
もうあまりやる人いないと思いますが、念のため。

camelcase

変数をキャメルケースで宣言。

個人で好みが分かれてキャメルケースで宣言されていたりスネークケースになっていたりすると混乱するため。
定数扱いのものは大文字・スネークケースでOKです。

// NG🚫
const variable_X = "X";

// OK✅
const variableX = "X";

// OK✅
const VARIABLE_Y = "YYY"
余談ですが、最新のバージョンでViteでプロジェクトを立ち上げると、ESLintが最新になっているはずなので、flat configになっています。