### PR TITLE
CNV-194 huskyでtypecheckができない問題

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
       "prettier --write",
       "eslint --fix",
       "npm run lint",
+      "bash -c 'tsc --noEmit'",
       "npm run format"
     ],
     "src/**/*.scss": [


### PR DESCRIPTION
## JIRAチケットURL

https://techno-kuro-novel.atlassian.net/browse/CNV-194

---
## 実装内容

- pre-commit時に、`tsc --no-emit`を実行できない問題の解決。

【原因】 
lint-stagedの公式リポジトリで説明されていた原因は以下。
- lint-stagedはステージングファイルのうち設定したパターンに一致するファイルを、設定したコマンドの引数として、自動的に渡す。
- しかし、コマンドでファイルが指定されてしまうと、`tsconfig.json`を無視するというTypeScriptの仕様がある。
- そのため、lint-stagedで`tsc --no-emit`を実行しようとしても、`tsconfig.json`の設定が無視されるため、「jsxが使えない～」とかのエラーが発生してしまう。
  - だから、いくら`tsconfig.json`の設定を見直したところで、全く解決できなかった...！！`tsconfig.json`を直しても無視されてた...！

https://github.com/lint-staged/lint-staged?tab=readme-ov-file#how-can-i-resolve-typescript-tsc-ignoring-tsconfigjson-when-lint-staged-runs-via-husky-hooks
https://www.typescriptlang.org/docs/handbook/tsconfig-json.html#using-tsconfigjson-or-jsconfigjson

【解決策】
- `bash`コマンドで`tsc`をラップする
  - `bash`のようなシェルコマンドは、プロジェクトフォルダーを見つけることができて設定ファイルを利用できるが、ファイルの指定はできない
  - TypeScriptは、ファイルを指定すると、プロジェクトフォルダーを見つけることができず`tsconfig.json`を利用できない
  - そのため、`bash`コマンドで`tsconfig.json`を利用できる状態にした上で、lint-stagedによる対象ファイルの指定をする



### 機能要件

- 本PRでは機能の実装を行っておらず、満たすべき機能要件はなし。

### 非機能要件

- 本PRでは機能の実装を行っておらず、満たすべき非機能要件はなし。

---

## 自身で確認した動作のエビデンス（スクショ等）

### 動作確認エビデンス1
- `npm run typecheck`を実行した場合

![スクリーンショット 2025-03-26 192757](https://github.com/user-attachments/assets/f582718e-3bdb-4f3e-8de0-add78b126491)


### 動作確認エビデンス2
- commitしようとした場合
  - 動作確認エビデンス1と同じエラーが出ていること

![スクリーンショット 2025-03-26 192909](https://github.com/user-attachments/assets/1648a943-5a9d-46e0-9b2e-42c3821ae024)

---

## 結合テスト・受入テストに持ち越すテスト項目（必ず1つ以上作成）
本PullReqで洗い出し記載して、Mergeしたら、以下に整理転記する
https://techno-kuro-novel.atlassian.net/wiki/spaces/Conovel/pages/38567991

### テスト要求1

### テスト要求2

### テスト要求3
