### PR TITLE
CNV-200 トップ画面の小説一覧取得をuseEffectにする

### DIFF
--- a/src/features/NovelList/index.tsx
+++ b/src/features/NovelList/index.tsx
@@ -1,10 +1,9 @@
 import Grid from '@mui/material/Grid';
-import { useState } from 'react'; //API動作確認用
+import { useEffect, useState } from 'react'; //API動作確認用
 import { NovelsApi } from '../../api/api'; //API動作確認用
 import NovelCardContainer from '../../components/novelCard/container';
 import { NovelListItem } from '../../types/types';
 import { convertNovelListResponse } from './convert';
-import { Box, Typography } from '@mui/material';
 import { axiosConfig } from '../../axiosConfig';
 
 /*APi動作確認用 */
@@ -14,18 +13,22 @@ const novelsApi = new NovelsApi(axiosConfig);
 const NovelList = () => {
   const [responseNovels, setResponseNovels] = useState<NovelListItem[]>([]);
 
-  const fetchNovels = async () => {
-    try {
-      const response = await novelsApi.getNovels();
-      const mappedResponse: NovelListItem[] = convertNovelListResponse(
-        response.data,
-      );
-      setResponseNovels(mappedResponse);
-    } catch (error) {
-      // TODO: エラー時の対応について要検討（エラーがわかるような画面にするかなど）
-      console.error('Error fetching sentences:', error);
-    }
-  };
+  useEffect(() => {
+    const fetchNovels = async () => {
+      try {
+        const response = await novelsApi.getNovels();
+        const mappedResponse: NovelListItem[] = convertNovelListResponse(
+          response.data,
+        );
+        setResponseNovels(mappedResponse);
+      } catch (error) {
+        // TODO: エラー時の対応について要検討（エラーがわかるような画面にするかなど）
+        console.error('Error fetching sentences:', error);
+      }
+    };
+
+    fetchNovels();
+  }, []);
 
   return (
     <>
@@ -70,36 +73,6 @@ const NovelList = () => {
           </Grid>
         ))}
       </Grid>
-
-      {/** API動作確認用 */}
-      <button onClick={fetchNovels}>Fetch Novels</button>
-      <Box>
-        {responseNovels.map((res) => (
-          <Box key={res.title_id}>
-            <Typography>title_id：{res.title_id}</Typography>
-            <Typography>title：{res.title}</Typography>
-            <Typography>
-              famous_sentence_text：{res.famous_sentence_text}
-            </Typography>
-            <Typography>author_user_id：{res.author_user_id}</Typography>
-            <Typography>author_user_name：{res.author_user_name}</Typography>
-            {/** // TODO：仮でindex0番目だけ */}
-            <Typography>
-              profile_icon_image：{res.profile_icon_image}
-            </Typography>
-            <Typography>title_genres：{res.title_genres[0]}</Typography>
-            <Typography>is_new：{res.is_new}</Typography>
-            <Typography>is_famous：{res.is_famous}</Typography>
-            <Typography>view_count：{res.view_count}</Typography>
-            <Typography>
-              evaluation_good_count：{res.evaluation_good_count}
-            </Typography>
-            <Typography>created_at：{res.created_at}</Typography>
-            <Typography>updated_at{res.updated_at}</Typography>
-            {/*API動作確認用　ここまで */}
-          </Box>
-        ))}
-      </Box>
     </>
   );
 };

--- a/src/features/NovelList/index.tsx
+++ b/src/features/NovelList/index.tsx
@@ -6,9 +6,7 @@ import { NovelListItem } from '../../types/types';
 import { convertNovelListResponse } from './convert';
 import { axiosConfig } from '../../axiosConfig';
 
-/*APi動作確認用 */
 const novelsApi = new NovelsApi(axiosConfig);
-/*APi動作確認用　ここまで */
 
 const NovelList = () => {
   const [responseNovels, setResponseNovels] = useState<NovelListItem[]>([]);
@@ -17,10 +15,10 @@ const NovelList = () => {
     const fetchNovels = async () => {
       try {
         const response = await novelsApi.getNovels();
-        const mappedResponse: NovelListItem[] = convertNovelListResponse(
+        const convertedResponse: NovelListItem[] = convertNovelListResponse(
           response.data,
         );
-        setResponseNovels(mappedResponse);
+        setResponseNovels(convertedResponse);
       } catch (error) {
         // TODO: エラー時の対応について要検討（エラーがわかるような画面にするかなど）
         console.error('Error fetching sentences:', error);

--- a/src/features/NovelList/index.tsx
+++ b/src/features/NovelList/index.tsx
@@ -1,6 +1,6 @@
 import Grid from '@mui/material/Grid';
-import { useEffect, useState } from 'react'; //API動作確認用
-import { NovelsApi } from '../../api/api'; //API動作確認用
+import { useEffect, useState } from 'react';
+import { NovelsApi } from '../../api/api';
 import NovelCardContainer from '../../components/novelCard/container';
 import { NovelListItem } from '../../types/types';
 import { convertNovelListResponse } from './convert';
@@ -65,7 +65,7 @@ const NovelList = () => {
                 sentence_hierarchy_count: 0,
               }}
               onClick={() => {
-                /* handle click */
+                // TODO：不要なonClick削除する
               }}
             />
           </Grid>


### PR DESCRIPTION
## JIRAチケットURL

https://techno-kuro-novel.atlassian.net/browse/CNV-200

---
## 実装内容

- トップ画面に来たときに小説一覧を表示するため、小説一覧取得処理を`useEffect`でくるんだ。
- API動作確認用ボタンはもういらないと思うので、削除。
- 不要なコメント削除。

### 機能要件

- トップ画面で小説一覧を表示できること

また、上記要件資料を参照し、漏れがないことを確認したら、チェックします。

[X] 要件漏れがないことを確認済み
[] 一部懸念あり

### 非機能要件

- 満たすべき非機能要件はなしの想定。

以下非機能要件を遵守すべき事項を確認しチェック
[] CORS制約
[] XSS防止
[] CSRF防止
[] 認証中トークン
[] 広告枠

---

## 自身で確認した動作のエビデンス（スクショ等）

### 動作確認エビデンス1
トップ画面に小説一覧が表示されていること

![スクリーンショット 2025-04-19 162816](https://github.com/user-attachments/assets/ec6d4a42-2999-4231-8102-e67e2f58a8e2)

---

## 結合テスト・受入テストに持ち越すテスト項目（必ず1つ以上作成）
本PullReqで洗い出し記載して、Mergeしたら、以下に整理転記する
https://techno-kuro-novel.atlassian.net/wiki/spaces/Conovel/pages/38567991

### テスト要求1

### テスト要求2

### テスト要求3
