### PR TITLE
[WIP]ラッパ関数の利用を提案

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -728,7 +728,7 @@ export const AuthApiFp = function (configuration?: Configuration) {
     ): Promise<
       (axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>
     > {
-      const localVarAxiosArgs = await localVarAxiosParamCreator.logOut(options);
+      const localVarAxiosArgs = await localVarAxiosParamCreator.logOut({...options, withCredentials: true});  // 認証時にクッキーを送る（手動で修正）
       const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
       const localVarOperationServerBasePath =
         operationServerMap['AuthApi.logOut']?.[localVarOperationServerIndex]
@@ -753,7 +753,7 @@ export const AuthApiFp = function (configuration?: Configuration) {
       (axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>
     > {
       const localVarAxiosArgs =
-        await localVarAxiosParamCreator.refreshToken(options);
+        await localVarAxiosParamCreator.refreshToken({...options, withCredentials: true});  // 認証時にクッキーを送る（手動で修正）
       const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
       const localVarOperationServerBasePath =
         operationServerMap['AuthApi.refreshToken']?.[
@@ -1880,7 +1880,7 @@ export const UsersApiFp = function (configuration?: Configuration) {
       (axios?: AxiosInstance, basePath?: string) => AxiosPromise<ViewMeUser>
     > {
       const localVarAxiosArgs =
-        await localVarAxiosParamCreator.getUserByMe({...options, withCredentials: true}); // 手動で修正（本当は避けたい）
+        await localVarAxiosParamCreator.getUserByMe({...options, withCredentials: true}); // 認証時にクッキーを送る（手動で修正）
       const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
       const localVarOperationServerBasePath =
         operationServerMap['UsersApi.getUserByMe']?.[

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -2107,14 +2107,14 @@ export class UsersApi extends BaseAPI {
    * @throws {RequiredError}
    * @memberof UsersApi
    */
-  public getUserByMe(onFailure?: () => Promise<void>, options?: RawAxiosRequestConfig) {
+  public getUserByMe(options?: RawAxiosRequestConfig) {
     const f = () => UsersApiFp(this.configuration)
       .getUserByMe(options)
       .then((request) => request(this.axios, this.basePath));
     const r = () => AuthApiFp(this.configuration)
       .refreshToken(options)
       .then((request) => request(this.axios, this.basePath));
-    return withAuth(f, r, onFailure ?? (() => Promise.resolve()));
+      return withAuth(f, r);
   }
 
   /**

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -2102,13 +2102,18 @@ export class UsersApi extends BaseAPI {
    *
    * @summary 自分自身のユーザーアカウント情報を取得
    * @param {*} [options] Override http request option.
+   * @param {Promise<void>} [onFailure] on authrization failured function
    * @throws {RequiredError}
    * @memberof UsersApi
    */
-  public getUserByMe(options?: RawAxiosRequestConfig) {
-    return UsersApiFp(this.configuration)
+  public getUserByMe(options?: RawAxiosRequestConfig, onFailure?: () => Promise<void>) {
+    const f = () => UsersApiFp(this.configuration)
       .getUserByMe(options)
       .then((request) => request(this.axios, this.basePath));
+    const r = () => AuthApiFp(this.configuration)
+      .refreshToken(options)
+      .then((request) => request(this.axios, this.basePath));
+    return withAuth(f, r, onFailure ?? (() => Promise.resolve()));
   }
 
   /**

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1880,7 +1880,7 @@ export const UsersApiFp = function (configuration?: Configuration) {
       (axios?: AxiosInstance, basePath?: string) => AxiosPromise<ViewMeUser>
     > {
       const localVarAxiosArgs =
-        await localVarAxiosParamCreator.getUserByMe(options);
+        await localVarAxiosParamCreator.getUserByMe({...options, withCredentials: true}); // 手動で修正（本当は避けたい）
       const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
       const localVarOperationServerBasePath =
         operationServerMap['UsersApi.getUserByMe']?.[

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -2102,7 +2102,7 @@ export class UsersApi extends BaseAPI {
    *
    * @summary 自分自身のユーザーアカウント情報を取得
    * @param {*} [options] Override http request option.
-   * @param {Promise<void>} [onFailure] on authrization failured function
+   * @param {Promise<void>} [onFailure] on authorization failure handler
    * @throws {RequiredError}
    * @memberof UsersApi
    */

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -38,6 +38,7 @@ import {
   // RequiredError, // 未使用：一時的にコメントアウト
   operationServerMap,
 } from './base';
+import { withAuth } from './functional';
 
 /**
  *
@@ -2106,7 +2107,7 @@ export class UsersApi extends BaseAPI {
    * @throws {RequiredError}
    * @memberof UsersApi
    */
-  public getUserByMe(options?: RawAxiosRequestConfig, onFailure?: () => Promise<void>) {
+  public getUserByMe(onFailure?: () => Promise<void>, options?: RawAxiosRequestConfig) {
     const f = () => UsersApiFp(this.configuration)
       .getUserByMe(options)
       .then((request) => request(this.axios, this.basePath));

--- a/src/api/functional.ts
+++ b/src/api/functional.ts
@@ -1,8 +1,4 @@
-import { AuthApi } from './api';
-import { axiosConfig } from '../axiosConfig';
-
-const authApi = new AuthApi(axiosConfig);
-
+// src/api/functional.ts
 export type LoginStatus = 'idle' | 'checking' | 'success' | 'failure';
 
 let loginStatus: LoginStatus = 'idle';
@@ -11,7 +7,6 @@ let statusChangeCallbacks: ((status: LoginStatus) => void)[] = [];
 export const subscribeToAuthStatus = (callback: (status: LoginStatus) => void) => {
   statusChangeCallbacks.push(callback);
   callback(loginStatus);
-  
   return () => {
     statusChangeCallbacks = statusChangeCallbacks.filter(cb => cb !== callback);
   };
@@ -26,6 +21,7 @@ export const getLoginStatus = (): LoginStatus => loginStatus;
 
 export const withAuth = async <T>(
   fn: () => Promise<T>,
+  refreshToken: () => Promise<any>,
   onAuthFailure: () => Promise<void>,
   onRefreshFailure?: () => Promise<void>,
 ): Promise<T | null> => {
@@ -37,9 +33,8 @@ export const withAuth = async <T>(
     if (error?.response?.status === 401) {
       try {
         setLoginStatus('checking');
-        const refreshRes = await authApi.refreshToken();
+        const refreshRes = await refreshToken();
         if (refreshRes.status !== 200) throw new Error('Refresh failed');
-
         const result = await fn();
         setLoginStatus('success');
         return result;

--- a/src/api/functional.ts
+++ b/src/api/functional.ts
@@ -1,4 +1,3 @@
-// src/api/functional.ts
 export type LoginStatus = 'idle' | 'checking' | 'success' | 'failure';
 
 let loginStatus: LoginStatus = 'idle';

--- a/src/api/functional.ts
+++ b/src/api/functional.ts
@@ -23,7 +23,7 @@ export const withAuth = async <T>(
   refreshToken: () => Promise<any>,
   onAuthFailure: () => Promise<void>,
   onRefreshFailure?: () => Promise<void>,
-): Promise<T | null> => {
+): Promise<T | null | undefined> => {
   try {
     return await fn();
   } catch (error: any) {

--- a/src/api/functional.ts
+++ b/src/api/functional.ts
@@ -3,6 +3,27 @@ import { axiosConfig } from '../axiosConfig';
 
 const authApi = new AuthApi(axiosConfig);
 
+export type LoginStatus = 'idle' | 'checking' | 'success' | 'failure';
+
+let loginStatus: LoginStatus = 'idle';
+let statusChangeCallbacks: ((status: LoginStatus) => void)[] = [];
+
+export const subscribeToAuthStatus = (callback: (status: LoginStatus) => void) => {
+  statusChangeCallbacks.push(callback);
+  callback(loginStatus);
+  
+  return () => {
+    statusChangeCallbacks = statusChangeCallbacks.filter(cb => cb !== callback);
+  };
+};
+
+const setLoginStatus = (status: LoginStatus) => {
+  loginStatus = status;
+  statusChangeCallbacks.forEach(callback => callback(status));
+};
+
+export const getLoginStatus = (): LoginStatus => loginStatus;
+
 export const withAuth = async <T>(
   fn: () => Promise<T>,
   onAuthFailure: () => Promise<void>,
@@ -11,24 +32,31 @@ export const withAuth = async <T>(
   try {
     return await fn();
   } catch (error: any) {
-    // 401 Unauthorized など、認証切れと判断する条件を調整可能
     if (error?.response?.status === 401) {
       try {
+        setLoginStatus('checking');
         const refreshRes = await authApi.refreshToken({ withCredentials: true });
         if (refreshRes.status !== 200) throw new Error('Refresh failed');
 
+        setLoginStatus('success');
         return await fn(); // 再試行
       } catch (refreshError) {
+        setLoginStatus('failure');
         await onAuthFailure();
         return null;
       }
     } else {
+      // 401以外のエラー - onRefreshFailureがあればそれを、なければonAuthFailureを実行
       if (onRefreshFailure) {
         await onRefreshFailure();
       } else {
         await onAuthFailure();
       }
-      return null;
+      return null; // 例外をスローせずnullを返す
     }
   }
+};
+
+export const resetAuthStatus = () => {
+  setLoginStatus('idle');
 };

--- a/src/api/functional.ts
+++ b/src/api/functional.ts
@@ -1,0 +1,23 @@
+export const withAuth = async <T>(
+  fn: () => Promise<T>,
+  onAuthFailure: () => Promise<void> = async () => { await logout(); },
+): Promise<T | null> => {
+  try {
+    return await fn();
+  } catch (error: any) {
+    // 401 Unauthorized など、認証切れと判断する条件を調整可能
+    if (error?.response?.status === 401) {
+      try {
+        const refreshRes = await authApi.refreshToken({ withCredentials: true });
+        if (refreshRes.status !== 200) throw new Error('Refresh failed');
+
+        return await fn(); // 再試行
+      } catch (refreshError) {
+        await onAuthFailure();
+        return null;
+      }
+    } else {
+      throw error; // 認証エラー以外はそのまま投げる
+    }
+  }
+};

--- a/src/api/functional.ts
+++ b/src/api/functional.ts
@@ -25,12 +25,12 @@ const setLoginStatus = (status: LoginStatus) => {
 export const getLoginStatus = (): LoginStatus => loginStatus;
 
 export const withAuth = async <T>(
-  fn: () => Promise<T>,
+  fn: (options?: { withCredentials?: boolean }) => Promise<T>,
   onAuthFailure: () => Promise<void>,
   onRefreshFailure?: () => Promise<void>,
 ): Promise<T | null> => {
   try {
-    const result = await fn();
+    const result = await fn({ withCredentials: true });
     setLoginStatus('success');
     return result;
   } catch (error: any) {
@@ -40,7 +40,7 @@ export const withAuth = async <T>(
         const refreshRes = await authApi.refreshToken({ withCredentials: true });
         if (refreshRes.status !== 200) throw new Error('Refresh failed');
 
-        const result = await fn(); // 再実行        
+        const result = await fn({ withCredentials: true });
         setLoginStatus('success');
         return result;
       } catch (refreshError) {
@@ -49,14 +49,13 @@ export const withAuth = async <T>(
         return null;
       }
     } else {
-      // 401以外のエラー - onRefreshFailureがあればそれを、なければonAuthFailureを実行
       setLoginStatus('failure');
       if (onRefreshFailure) {
         await onRefreshFailure();
       } else {
         await onAuthFailure();
       }
-      return null; // 例外をスローせずnullを返す
+      return null;
     }
   }
 };

--- a/src/api/functional.ts
+++ b/src/api/functional.ts
@@ -25,22 +25,22 @@ const setLoginStatus = (status: LoginStatus) => {
 export const getLoginStatus = (): LoginStatus => loginStatus;
 
 export const withAuth = async <T>(
-  fn: (options?: { withCredentials?: boolean }) => Promise<T>,
+  fn: () => Promise<T>,
   onAuthFailure: () => Promise<void>,
   onRefreshFailure?: () => Promise<void>,
 ): Promise<T | null> => {
   try {
-    const result = await fn({ withCredentials: true });
+    const result = await fn();
     setLoginStatus('success');
     return result;
   } catch (error: any) {
     if (error?.response?.status === 401) {
       try {
         setLoginStatus('checking');
-        const refreshRes = await authApi.refreshToken({ withCredentials: true });
+        const refreshRes = await authApi.refreshToken();
         if (refreshRes.status !== 200) throw new Error('Refresh failed');
 
-        const result = await fn({ withCredentials: true });
+        const result = await fn();
         setLoginStatus('success');
         return result;
       } catch (refreshError) {

--- a/src/api/functional.ts
+++ b/src/api/functional.ts
@@ -1,6 +1,12 @@
+import { AuthApi } from './api';
+import { axiosConfig } from '../axiosConfig';
+
+const authApi = new AuthApi(axiosConfig);
+
 export const withAuth = async <T>(
   fn: () => Promise<T>,
-  onAuthFailure: () => Promise<void> = async () => { await logout(); },
+  onAuthFailure: () => Promise<void>,
+  onRefreshFailure?: () => Promise<void>,
 ): Promise<T | null> => {
   try {
     return await fn();
@@ -17,7 +23,12 @@ export const withAuth = async <T>(
         return null;
       }
     } else {
-      throw error; // 認証エラー以外はそのまま投げる
+      if (onRefreshFailure) {
+        await onRefreshFailure();
+      } else {
+        await onAuthFailure();
+      }
+      return null;
     }
   }
 };

--- a/src/api/functional.ts
+++ b/src/api/functional.ts
@@ -1,4 +1,4 @@
-export type LoginStatus = 'idle' | 'checking' | 'success' | 'failure';
+type LoginStatus = 'idle' | 'checking' | 'failure';
 
 let loginStatus: LoginStatus = 'idle';
 let statusChangeCallbacks: ((status: LoginStatus) => void)[] = [];
@@ -16,7 +16,7 @@ const setLoginStatus = (status: LoginStatus) => {
   statusChangeCallbacks.forEach(callback => callback(status));
 };
 
-export const getLoginStatus = (): LoginStatus => loginStatus;
+const getLoginStatus = (): LoginStatus => loginStatus;
 
 export const withAuth = async <T>(
   fn: () => Promise<T>,
@@ -25,21 +25,22 @@ export const withAuth = async <T>(
   onRefreshFailure?: () => Promise<void>,
 ): Promise<T | null> => {
   try {
-    const result = await fn();
-    setLoginStatus('success');
-    return result;
+    return await fn();
   } catch (error: any) {
     if (error?.response?.status === 401) {
       try {
-        setLoginStatus('checking');
-        const refreshRes = await refreshToken();
-        if (refreshRes.status !== 200) throw new Error('Refresh failed');
-        const result = await fn();
-        setLoginStatus('success');
-        return result;
+        if (getLoginStatus() === 'idle') {
+          setLoginStatus('checking');
+          const refreshRes = await refreshToken();
+          if (refreshRes.status !== 200) throw new Error('Refresh failed');
+          const result = await fn();
+          setLoginStatus('idle');
+          return result;
+        }
       } catch (refreshError) {
         setLoginStatus('failure');
         await onAuthFailure();
+        setLoginStatus('idle');
         return null;
       }
     } else {
@@ -49,11 +50,8 @@ export const withAuth = async <T>(
       } else {
         await onAuthFailure();
       }
+      setLoginStatus('idle');
       return null;
     }
   }
-};
-
-export const resetAuthStatus = () => {
-  setLoginStatus('idle');
 };

--- a/src/api/functional.ts
+++ b/src/api/functional.ts
@@ -21,7 +21,6 @@ const getLoginStatus = (): LoginStatus => loginStatus;
 export const withAuth = async <T>(
   fn: () => Promise<T>,
   refreshToken: () => Promise<any>,
-  onAuthFailure: () => Promise<void>,
   onRefreshFailure?: () => Promise<void>,
 ): Promise<T | null | undefined> => {
   try {
@@ -39,7 +38,6 @@ export const withAuth = async <T>(
         }
       } catch (refreshError) {
         setLoginStatus('failure');
-        await onAuthFailure();
         setLoginStatus('idle');
         return null;
       }
@@ -47,9 +45,7 @@ export const withAuth = async <T>(
       setLoginStatus('failure');
       if (onRefreshFailure) {
         await onRefreshFailure();
-      } else {
-        await onAuthFailure();
-      }
+      } 
       setLoginStatus('idle');
       return null;
     }

--- a/src/api/functional.ts
+++ b/src/api/functional.ts
@@ -40,8 +40,9 @@ export const withAuth = async <T>(
         const refreshRes = await authApi.refreshToken({ withCredentials: true });
         if (refreshRes.status !== 200) throw new Error('Refresh failed');
 
+        const result = await fn(); // 再実行        
         setLoginStatus('success');
-        return await fn(); // 再試行
+        return result;
       } catch (refreshError) {
         setLoginStatus('failure');
         await onAuthFailure();

--- a/src/api/functional.ts
+++ b/src/api/functional.ts
@@ -30,7 +30,9 @@ export const withAuth = async <T>(
   onRefreshFailure?: () => Promise<void>,
 ): Promise<T | null> => {
   try {
-    return await fn();
+    const result = await fn();
+    setLoginStatus('success');
+    return result;
   } catch (error: any) {
     if (error?.response?.status === 401) {
       try {
@@ -47,6 +49,7 @@ export const withAuth = async <T>(
       }
     } else {
       // 401以外のエラー - onRefreshFailureがあればそれを、なければonAuthFailureを実行
+      setLoginStatus('failure');
       if (onRefreshFailure) {
         await onRefreshFailure();
       } else {

--- a/src/axiosConfig.ts
+++ b/src/axiosConfig.ts
@@ -4,8 +4,5 @@ const basePath = import.meta.env.VITE_API_BASE_URL;
 
 export const axiosConfig = new Configuration({
   basePath,
-  // baseOptions: {
-  //   withCredentials: true,
-  // }, // 全てのリクエストにwithCredentialsを適用する場合はコメントアウトを外す
   // apiKey: 'your-api-key', // APIキーが必要な場合は設定
 });

--- a/src/axiosConfig.ts
+++ b/src/axiosConfig.ts
@@ -4,5 +4,8 @@ const basePath = import.meta.env.VITE_API_BASE_URL;
 
 export const axiosConfig = new Configuration({
   basePath,
+  // baseOptions: {
+  //   withCredentials: true,
+  // }, // 全てのリクエストにwithCredentialsを適用する場合はコメントアウトを外す
   // apiKey: 'your-api-key', // APIキーが必要な場合は設定
 });

--- a/src/features/NovelList/index.tsx
+++ b/src/features/NovelList/index.tsx
@@ -5,16 +5,31 @@ import NovelCardContainer from '../../components/novelCard/container';
 import { NovelListItem } from '../../types/types';
 import { convertNovelListResponse } from './convert';
 import { axiosConfig } from '../../axiosConfig';
+// import { withAuth } from '../../api/functional'; // 認証付きでAPIを呼び出すテスト  
+// import { useAuth } from '../../providers/auth'; // 認証付きでAPIを呼び出すテスト  
 
 const novelsApi = new NovelsApi(axiosConfig);
 
 const NovelList = () => {
   const [responseNovels, setResponseNovels] = useState<NovelListItem[]>([]);
+  // const { logout } = useAuth(); // 認証付きでAPIを呼び出すテスト  
 
   useEffect(() => {
     const fetchNovels = async () => {
       try {
         const response = await novelsApi.getNovels();
+
+        // 認証付きでAPIを呼び出すテスト        
+        // const response = await withAuth(novelsApi.getNovels, logout);
+        // console.log('Auth response:', response);
+
+        // if (response) {
+        //   console.log('小説の取得に成功');
+        // } else {
+        //   console.error('小説の取得に失敗→ログアウト');
+        //   return
+        // }
+
         const convertedResponse: NovelListItem[] = convertNovelListResponse(
           response.data,
         );

--- a/src/features/NovelList/index.tsx
+++ b/src/features/NovelList/index.tsx
@@ -5,30 +5,16 @@ import NovelCardContainer from '../../components/novelCard/container';
 import { NovelListItem } from '../../types/types';
 import { convertNovelListResponse } from './convert';
 import { axiosConfig } from '../../axiosConfig';
-// import { withAuth } from '../../api/functional'; // 認証付きでAPIを呼び出すテスト  
-// import { useAuth } from '../../providers/auth'; // 認証付きでAPIを呼び出すテスト  
 
 const novelsApi = new NovelsApi(axiosConfig);
 
 const NovelList = () => {
   const [responseNovels, setResponseNovels] = useState<NovelListItem[]>([]);
-  // const { logout } = useAuth(); // 認証付きでAPIを呼び出すテスト  
 
   useEffect(() => {
     const fetchNovels = async () => {
       try {
         const response = await novelsApi.getNovels();
-
-        // 認証付きでAPIを呼び出すテスト        
-        // const response = await withAuth(novelsApi.getNovels, logout);
-        // console.log('Auth response:', response);
-
-        // if (response) {
-        //   console.log('小説の取得に成功');
-        // } else {
-        //   console.error('小説の取得に失敗→ログアウト');
-        //   return
-        // }
 
         const convertedResponse: NovelListItem[] = convertNovelListResponse(
           response.data,

--- a/src/providers/auth.tsx
+++ b/src/providers/auth.tsx
@@ -3,7 +3,7 @@ import React, { createContext, useContext, useEffect, useState } from 'react';
 import { UsersApi } from '../api/api';
 import { AuthApi } from '../api/api';
 import { axiosConfig } from '../axiosConfig';
-import { withAuth } from '../api/functional';
+import { withAuth, subscribeToAuthStatus, getLoginStatus, resetAuthStatus, LoginStatus } from '../api/functional';
 
 // 型定義
 export interface User {
@@ -44,8 +44,12 @@ export const useAuth = () => {
 export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   const [currentUser, setCurrentUser] = useState<User | null>(null);
 
-  const setLoginStatus = (status: 'checking' | 'success' | 'failure') => {
-    sessionStorage.setItem('loginStatus', status);
+  // loginStatusはfunctional.tsで管理するのでsessionStorageは不要
+  // ただし、もともとのsetLoginStatusのインターフェースは維持
+  const setLoginStatus = (status: LoginStatus) => {
+    // 互換のため。UI用state管理はfunctional.ts側
+    // sessionStorage.setItem('loginStatus', status); // 不要
+    // functional.tsで管理されるため何もせず
   };
 
   const logout = async () => {
@@ -54,21 +58,22 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     } catch (e) {
       console.error('ログアウトAPI呼び出しでエラー:', e);
     }
-
-    setLoginStatus('failure');
+    resetAuthStatus(); // functional.tsでloginStatusをidleに戻す
     setCurrentUser(null);
-    sessionStorage.setItem('loginStatus', 'failure');
+    // sessionStorage.setItem('loginStatus', 'failure'); // 不要
   };
+  
+  const getUserByMe = () => usersApi.getUserByMe({ withCredentials: true });
 
   const fetchCurrentUserId = async () => {
-    if (sessionStorage.getItem('loginStatus') !== 'checking') return;
+    // functional.tsの状態を参照
+    if (getLoginStatus() !== 'checking') return;
 
-    const getUserByMe = () => usersApi.getUserByMe({ withCredentials: true });
-    const handleAuthFailure = () => logout();
-    const response = await withAuth(getUserByMe, handleAuthFailure);
+    // logout自体がasync functionなのでそのまま渡す
+    const response = await withAuth(getUserByMe, logout);
 
-    if (response.data && response.data.user_id) {
-      setLoginStatus('success');
+    if (response?.data?.user_id) {
+      // setLoginStatus('success'); // 管理はfunctional.ts側
       setCurrentUser(response.data as User);
       return;
     }
@@ -76,7 +81,12 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   };
 
   useEffect(() => {
-    setLoginStatus('checking');
+    // functional.tsでloginStatusをcheckingに
+    resetAuthStatus(); // 必要に応じてloginStatusを初期化
+    subscribeToAuthStatus((status) => {
+      // 状態変更で強制的に再レンダリングしたい場合はstate化も可
+      // ここではcurrentUser以外UI反映がないので省略
+    });
     setCurrentUser(null);
     fetchCurrentUserId();
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/providers/auth.tsx
+++ b/src/providers/auth.tsx
@@ -44,14 +44,6 @@ export const useAuth = () => {
 export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   const [currentUser, setCurrentUser] = useState<User | null>(null);
 
-  // loginStatusはfunctional.tsで管理するのでsessionStorageは不要
-  // ただし、もともとのsetLoginStatusのインターフェースは維持
-  const setLoginStatus = (status: LoginStatus) => {
-    // 互換のため。UI用state管理はfunctional.ts側
-    // sessionStorage.setItem('loginStatus', status); // 不要
-    // functional.tsで管理されるため何もせず
-  };
-
   const logout = async () => {
     try {
       await authApi.logOut();
@@ -60,7 +52,6 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     }
     resetAuthStatus(); // functional.tsでloginStatusをidleに戻す
     setCurrentUser(null);
-    // sessionStorage.setItem('loginStatus', 'failure'); // 不要
   };
   
   const getUserByMe = () => usersApi.getUserByMe();
@@ -73,7 +64,6 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     const response = await withAuth(getUserByMe, logout);
 
     if (response?.data?.user_id) {
-      // setLoginStatus('success'); // 管理はfunctional.ts側
       setCurrentUser(response.data as User);
       return;
     }

--- a/src/providers/auth.tsx
+++ b/src/providers/auth.tsx
@@ -83,13 +83,18 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   useEffect(() => {
     // functional.tsでloginStatusを初期化（idle）
     resetAuthStatus(); // 必要に応じてloginStatusを初期化
-    subscribeToAuthStatus((status) => {
-      // 状態変更で強制的に再レンダリングしたい場合はstate化も可
-      // ここではcurrentUser以外UI反映がないので省略
+    // 📌 重要：unsubscribe関数を受け取る
+    const unsubscribe = subscribeToAuthStatus((status) => {
+      // 必要に応じて状態変更時の処理を追加
+      console.log('Auth status changed:', status);
     });
     setCurrentUser(null);
     fetchCurrentUserId();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    
+    // 📌 重要：クリーンアップ関数でunsubscribe
+    return () => {
+      unsubscribe();
+    };
   }, []);
 
   return (

--- a/src/providers/auth.tsx
+++ b/src/providers/auth.tsx
@@ -81,7 +81,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   };
 
   useEffect(() => {
-    // functional.tsでloginStatusをcheckingに
+    // functional.tsでloginStatusを初期化（idle）
     resetAuthStatus(); // 必要に応じてloginStatusを初期化
     subscribeToAuthStatus((status) => {
       // 状態変更で強制的に再レンダリングしたい場合はstate化も可

--- a/src/providers/auth.tsx
+++ b/src/providers/auth.tsx
@@ -63,8 +63,9 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     // sessionStorage.setItem('loginStatus', 'failure'); // 不要
   };
   
-  const getUserByMe = (options?: { withCredentials?: boolean }) => 
-  usersApi.getUserByMe(options);
+  // const getUserByMe = (options?: { withCredentials?: boolean }) => 
+  // usersApi.getUserByMe(options);
+  const getUserByMe = () => usersApi.getUserByMe(); // 一旦引数なしに戻す
 
   const fetchCurrentUserId = async () => {
     // functional.tsの状態を参照

--- a/src/providers/auth.tsx
+++ b/src/providers/auth.tsx
@@ -54,7 +54,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
   const logout = async () => {
     try {
-      await authApi.logOut({ withCredentials: true });
+      await authApi.logOut();
     } catch (e) {
       console.error('ログアウトAPI呼び出しでエラー:', e);
     }
@@ -63,9 +63,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     // sessionStorage.setItem('loginStatus', 'failure'); // 不要
   };
   
-  // const getUserByMe = (options?: { withCredentials?: boolean }) => 
-  // usersApi.getUserByMe(options);
-  const getUserByMe = () => usersApi.getUserByMe(); // 一旦引数なしに戻す
+  const getUserByMe = () => usersApi.getUserByMe();
 
   const fetchCurrentUserId = async () => {
     // functional.tsの状態を参照

--- a/src/providers/auth.tsx
+++ b/src/providers/auth.tsx
@@ -63,16 +63,9 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   const fetchCurrentUserId = async () => {
     if (sessionStorage.getItem('loginStatus') !== 'checking') return;
 
-    const response = await withAuth(
-      (
-        async () => {
-          return await usersApi.getUserByMe({ withCredentials: true });
-        }
-      ),
-      (
-        async () => await logout()
-      )
-    );
+    const getUserByMe = () => usersApi.getUserByMe({ withCredentials: true });
+    const handleAuthFailure = () => logout();
+    const response = await withAuth(getUserByMe, handleAuthFailure);
 
     if (response.data && response.data.user_id) {
       setLoginStatus('success');

--- a/src/providers/auth.tsx
+++ b/src/providers/auth.tsx
@@ -63,7 +63,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     // sessionStorage.setItem('loginStatus', 'failure'); // 不要
   };
   
-  const getUserByMe = () => usersApi.getUserByMe({ withCredentials: true });
+  const getUserByMe = () => usersApi.getUserByMe();
 
   const fetchCurrentUserId = async () => {
     // functional.tsの状態を参照

--- a/src/providers/auth.tsx
+++ b/src/providers/auth.tsx
@@ -3,7 +3,7 @@ import React, { createContext, useContext, useEffect, useState } from 'react';
 import { UsersApi } from '../api/api';
 import { AuthApi } from '../api/api';
 import { axiosConfig } from '../axiosConfig';
-import { withAuth, subscribeToAuthStatus, getLoginStatus, resetAuthStatus, LoginStatus } from '../api/functional';
+import { useNavigate } from 'react-router';
 
 // 型定義
 export interface User {
@@ -43,6 +43,7 @@ export const useAuth = () => {
 
 export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   const [currentUser, setCurrentUser] = useState<User | null>(null);
+  const navigate = useNavigate();
 
   const logout = async () => {
     try {
@@ -50,41 +51,24 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     } catch (e) {
       console.error('ログアウトAPI呼び出しでエラー:', e);
     }
-    resetAuthStatus(); // functional.tsでloginStatusをidleに戻す
     setCurrentUser(null);
   };
   
-  const getUserByMe = () => usersApi.getUserByMe();
-
   const fetchCurrentUserId = async () => {
-    // functional.tsの状態を参照
-    if (getLoginStatus() !== 'idle') return;
-
-    // logout自体がasync functionなのでそのまま渡す
-    const response = await withAuth(getUserByMe, logout);
+    // jwt, refresh両方失敗時にはlgin画面へリダイレクト
+    const response = await usersApi.getUserByMe(async () => {
+      navigate('/login'); }
+    );
 
     if (response?.data?.user_id) {
       setCurrentUser(response.data as User);
       return;
     }
-    // TODO: 認証エラー時の画面遷移などを記載すること！
   };
 
   useEffect(() => {
-    // functional.tsでloginStatusを初期化（idle）
-    resetAuthStatus(); // 必要に応じてloginStatusを初期化
-    // 📌 重要：unsubscribe関数を受け取る
-    const unsubscribe = subscribeToAuthStatus((status) => {
-      // 必要に応じて状態変更時の処理を追加
-      console.log('Auth status changed:', status);
-    });
-    setCurrentUser(null);
+    // 初期化時に現在のユーザー情報を取得
     fetchCurrentUserId();
-    
-    // 📌 重要：クリーンアップ関数でunsubscribe
-    return () => {
-      unsubscribe();
-    };
   }, []);
 
   return (

--- a/src/providers/auth.tsx
+++ b/src/providers/auth.tsx
@@ -55,14 +55,18 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   };
   
   const fetchCurrentUserId = async () => {
-    // jwt, refresh両方失敗時にはlgin画面へリダイレクト
-    const response = await usersApi.getUserByMe(async () => {
-      navigate('/login'); }
-    );
-
-    if (response?.data?.user_id) {
-      setCurrentUser(response.data as User);
-      return;
+    try {
+      const response = await usersApi.getUserByMe();
+      // 認証成功時
+      if (response?.data?.user_id) {
+        setCurrentUser(response.data as User);
+        return;
+      }
+      // 認証失敗時
+      navigate('/login');
+    } catch (error) {
+      // その他（ネットワークエラーなど）
+      navigate('/login');
     }
   };
 

--- a/src/providers/auth.tsx
+++ b/src/providers/auth.tsx
@@ -3,6 +3,7 @@ import React, { createContext, useContext, useEffect, useState } from 'react';
 import { UsersApi } from '../api/api';
 import { AuthApi } from '../api/api';
 import { axiosConfig } from '../axiosConfig';
+import { withAuth } from '../api/functional';
 
 // 型定義
 export interface User {
@@ -62,39 +63,23 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   const fetchCurrentUserId = async () => {
     if (sessionStorage.getItem('loginStatus') !== 'checking') return;
 
-    try {
-      const response = await usersApi.getUserByMe({ withCredentials: true });
-      if (response.data && response.data.user_id) {
-        setLoginStatus('success');
-        setCurrentUser(response.data as User);
-        return;
-      }
-      throw new Error('No user_id');
-    } catch (error) {
-      setLoginStatus('failure');
-      try {
-        const refreshRes = await authApi.refreshToken({
-          withCredentials: true,
-        });
-        if (refreshRes.status !== 200) {
-          throw new Error('Refresh failed');
+    const response = await withAuth(
+      (
+        async () => {
+          return await usersApi.getUserByMe({ withCredentials: true });
         }
+      ),
+      (
+        async () => await logout()
+      )
+    );
 
-        setLoginStatus('checking');
-        const retryResponse = await usersApi.getUserByMe({
-          withCredentials: true,
-        });
-        if (!(retryResponse.data && retryResponse.data.user_id)) {
-          throw new Error('No user_id after refresh');
-        }
-
-        setLoginStatus('success');
-        setCurrentUser(retryResponse.data as User);
-        return;
-      } catch (refreshError) {
-        await logout();
-      }
+    if (response.data && response.data.user_id) {
+      setLoginStatus('success');
+      setCurrentUser(response.data as User);
+      return;
     }
+    throw new Error('No user_id');
   };
 
   useEffect(() => {

--- a/src/providers/auth.tsx
+++ b/src/providers/auth.tsx
@@ -77,7 +77,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       setCurrentUser(response.data as User);
       return;
     }
-    throw new Error('No user_id');
+    // TODO: 認証エラー時の画面遷移などを記載すること！
   };
 
   useEffect(() => {

--- a/src/providers/auth.tsx
+++ b/src/providers/auth.tsx
@@ -21,7 +21,7 @@ export interface User {
 export interface AuthContextType {
   currentUser: User | null;
   setCurrentUser: React.Dispatch<React.SetStateAction<User | null>>;
-  logout: () => void;
+  logout: () => Promise<void>;
 }
 
 export interface AuthProviderProps {

--- a/src/providers/auth.tsx
+++ b/src/providers/auth.tsx
@@ -67,7 +67,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
   const fetchCurrentUserId = async () => {
     // functional.tsの状態を参照
-    if (getLoginStatus() !== 'checking') return;
+    if (getLoginStatus() !== 'idle') return;
 
     // logout自体がasync functionなのでそのまま渡す
     const response = await withAuth(getUserByMe, logout);

--- a/src/providers/auth.tsx
+++ b/src/providers/auth.tsx
@@ -63,7 +63,8 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     // sessionStorage.setItem('loginStatus', 'failure'); // 不要
   };
   
-  const getUserByMe = () => usersApi.getUserByMe();
+  const getUserByMe = (options?: { withCredentials?: boolean }) => 
+  usersApi.getUserByMe(options);
 
   const fetchCurrentUserId = async () => {
     // functional.tsの状態を参照


### PR DESCRIPTION
## JIRAチケットURL


---
## 実装内容

### 機能要件

- リフレッシュトークンで実行したかったAPIの再実行を担うラッパ関数を作成
👉functional.ts / withAuth
- functional.ts 側で状態管理（session storage を使わない）
👉functional.ts / loginStatus
- auth.tsx を上記に合わせて修正
👉コード簡素化
👉状態管理意識
👉変更前後の解説
👉unsubscribe を意識

[x] 要件漏れがないことを確認済み
[x] 一部懸念あり
👉コメント部がTODOになってる

### 非機能要件
なし
[] CORS制約
[] XSS防止
[] CSRF防止
[] 認証中トークン
[] 広告枠

---

## 自身で確認した動作のエビデンス（スクショ等）

### 動作確認エビデンス1
例　未読通知を複数ページに渡って閲覧して、既読になる様子

### 動作確認エビデンス2

---

## 結合テスト・受入テストに持ち越すテスト項目（必ず1つ以上作成）
本PullReqで洗い出し記載して、Mergeしたら、以下に整理転記する
https://techno-kuro-novel.atlassian.net/wiki/spaces/Conovel/pages/38567991

### テスト要求1

### テスト要求2

### テスト要求3
