### PR TITLE
CNV-212 [フロント]小説投稿画面フッターが隠れてしまう

### DIFF
--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -14,7 +14,7 @@ export const Footer = () => {
         padding: '8px',
         justifyContent: 'space-between',
         boxSizing: 'border-box',
-        position: 'fixed',
+        position: 'sticky',
         left: 0,
         bottom: 0,
         zIndex: 2000,

--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -14,8 +14,11 @@ export const Footer = () => {
         padding: '8px',
         justifyContent: 'space-between',
         boxSizing: 'border-box',
-        position: 'sticky',
-        bottom: '0',
+        position: 'fixed',
+        left: 0,
+        bottom: 0,
+        zIndex: 2000,
+        boxShadow: '0 -2px 8px rgba(0,0,0,0.15)',
       }}
     >
       {/** 広告エリア */}


### PR DESCRIPTION
## JIRAチケットURL

[[フロント]小説投稿画面フッターが隠れてしまう](http://techno-kuro-novel.atlassian.net/browse/CNV-212)

---
## 実装内容

- 小説閲覧画面にて、フッターと子投稿が被ってしまう問題を解消
  - チケットに記載して頂いた解決方法を用いて解消
  - `position: fixed`だと、子投稿が上に上がり切らず、フッターに重なってしまうため、`sticky`のままにした

### 機能要件

- 新規の機能開発ではなく、今回のチケットで満たすべき機能要件はなし。

### 非機能要件

- 新規の機能開発ではなく、今回のチケットで満たすべき非機能要件はなし。

---

## 自身で確認した動作のエビデンス（スクショ等）

### 動作確認エビデンス1
スクロールしてみて、子投稿とフッターが被っていないことを確認

https://github.com/user-attachments/assets/c960dd6d-a337-44e0-8bcf-fe456127ae66

---

## 結合テスト・受入テストに持ち越すテスト項目（必ず1つ以上作成）
本PullReqで洗い出し記載して、Mergeしたら、以下に整理転記する
https://techno-kuro-novel.atlassian.net/wiki/spaces/Conovel/pages/38567991

### テスト要求1

### テスト要求2

### テスト要求3
