### PR TITLE
/novels/{titleId}のレスポンスにfirstSentencesIdパラメータを追加(CNV-232)

### DIFF
--- a/openapigen/api.ts
+++ b/openapigen/api.ts
@@ -567,7 +567,23 @@ export interface ViewEvaluation {
    * @memberof ViewEvaluation
    */
   evaluationStayCount?: number;
+  /**
+   * 投稿に対するログインユーザーの評価状態
+   * @type {string}
+   * @memberof ViewEvaluation
+   */
+  userEvaluation?: ViewEvaluationUserEvaluationEnum | null;
 }
+
+export const ViewEvaluationUserEvaluationEnum = {
+  Good: "good",
+  Bad: "bad",
+  Stay: "stay",
+} as const;
+
+export type ViewEvaluationUserEvaluationEnum =
+  (typeof ViewEvaluationUserEvaluationEnum)[keyof typeof ViewEvaluationUserEvaluationEnum];
+
 /**
  *
  * @export

--- a/openapigen/api.ts
+++ b/openapigen/api.ts
@@ -417,6 +417,12 @@ export interface Sentence {
    */
   evaluationStayCount?: number;
   /**
+   * 投稿に対するログインユーザーの評価状態
+   * @type {string}
+   * @memberof Sentence
+   */
+  userEvaluation?: SentenceUserEvaluationEnum | null;
+  /**
    * 投稿日時
    * @type {string}
    * @memberof Sentence
@@ -429,6 +435,16 @@ export interface Sentence {
    */
   updatedAt?: string;
 }
+
+export const SentenceUserEvaluationEnum = {
+  Good: "good",
+  Bad: "bad",
+  Stay: "stay",
+} as const;
+
+export type SentenceUserEvaluationEnum =
+  (typeof SentenceUserEvaluationEnum)[keyof typeof SentenceUserEvaluationEnum];
+
 /**
  *
  * @export

--- a/openapigen/api.ts
+++ b/openapigen/api.ts
@@ -251,6 +251,12 @@ export interface NovelDetail {
    * @memberof NovelDetail
    */
   overview?: string;
+  /**
+   * 小説の最初の投稿のid
+   * @type {number}
+   * @memberof NovelDetail
+   */
+  firstSentenceId?: number;
 }
 /**
  *

--- a/openapigen/docs/NovelDetail.md
+++ b/openapigen/docs/NovelDetail.md
@@ -22,6 +22,7 @@
 | **sentenceHierarchyCount** | **number**              | 小説に投稿された投稿の階層数                                 | [optional] [default to undefined] |
 | **readerCount**            | **number**              | 小説を読んだユーザーの数                                     | [optional] [default to undefined] |
 | **overview**               | **string**              | 小説のあらすじ                                               | [optional] [default to undefined] |
+| **firstSentenceId**        | **number**              | 小説の最初の投稿のid                                         | [optional] [default to undefined] |
 
 ## Example
 
@@ -47,6 +48,7 @@ const instance: NovelDetail = {
   sentenceHierarchyCount,
   readerCount,
   overview,
+  firstSentenceId,
 };
 ```
 

--- a/openapigen/docs/Sentence.md
+++ b/openapigen/docs/Sentence.md
@@ -11,6 +11,7 @@
 | **profileIconImage**    | **string** | 投稿ユーザーアイコン画像のurl                                | [optional] [default to undefined] |
 | **evaluationGoodCount** | **number** | 投稿に対するGood評価の数                                     | [optional] [default to undefined] |
 | **evaluationStayCount** | **number** | 投稿に対するStay評価の数                                     | [optional] [default to undefined] |
+| **userEvaluation**      | **string** | 投稿に対するログインユーザーの評価状態                       | [optional] [default to undefined] |
 | **createdAt**           | **string** | 投稿日時                                                     | [optional] [default to undefined] |
 | **updatedAt**           | **string** | 修正日時                                                     | [optional] [default to undefined] |
 
@@ -27,6 +28,7 @@ const instance: Sentence = {
   profileIconImage,
   evaluationGoodCount,
   evaluationStayCount,
+  userEvaluation,
   createdAt,
   updatedAt,
 };

--- a/openapigen/docs/ViewEvaluation.md
+++ b/openapigen/docs/ViewEvaluation.md
@@ -2,11 +2,12 @@
 
 ## Properties
 
-| Name                    | Type       | Description        | Notes                             |
-| ----------------------- | ---------- | ------------------ | --------------------------------- |
-| **sentenceId**          | **number** | 評価対象の投稿のID | [optional] [default to undefined] |
-| **evaluationGoodCount** | **number** | Good評価の数       | [optional] [default to undefined] |
-| **evaluationStayCount** | **number** | Stay評価の数       | [optional] [default to undefined] |
+| Name                    | Type       | Description                            | Notes                             |
+| ----------------------- | ---------- | -------------------------------------- | --------------------------------- |
+| **sentenceId**          | **number** | 評価対象の投稿のID                     | [optional] [default to undefined] |
+| **evaluationGoodCount** | **number** | Good評価の数                           | [optional] [default to undefined] |
+| **evaluationStayCount** | **number** | Stay評価の数                           | [optional] [default to undefined] |
+| **userEvaluation**      | **string** | 投稿に対するログインユーザーの評価状態 | [optional] [default to undefined] |
 
 ## Example
 
@@ -17,6 +18,7 @@ const instance: ViewEvaluation = {
   sentenceId,
   evaluationGoodCount,
   evaluationStayCount,
+  userEvaluation,
 };
 ```
 

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -583,9 +583,9 @@ export interface ViewEvaluation {
 }
 
 export const ViewEvaluationUserEvaluationEnum = {
-  Good: "good",
-  Bad: "bad",
-  Stay: "stay",
+  Good: 'good',
+  Bad: 'bad',
+  Stay: 'stay',
 } as const;
 
 export type ViewEvaluationUserEvaluationEnum =

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -444,9 +444,9 @@ export interface Sentence {
 }
 
 export const SentenceUserEvaluationEnum = {
-  Good: "good",
-  Bad: "bad",
-  Stay: "stay",
+  Good: 'good',
+  Bad: 'bad',
+  Stay: 'stay',
 } as const;
 
 export type SentenceUserEvaluationEnum =
@@ -574,7 +574,23 @@ export interface ViewEvaluation {
    * @memberof ViewEvaluation
    */
   evaluationStayCount?: number;
+  /**
+   * 投稿に対するログインユーザーの評価状態
+   * @type {string}
+   * @memberof ViewEvaluation
+   */
+  userEvaluation?: ViewEvaluationUserEvaluationEnum | null;
 }
+
+export const ViewEvaluationUserEvaluationEnum = {
+  Good: "good",
+  Bad: "bad",
+  Stay: "stay",
+} as const;
+
+export type ViewEvaluationUserEvaluationEnum =
+  (typeof ViewEvaluationUserEvaluationEnum)[keyof typeof ViewEvaluationUserEvaluationEnum];
+
 /**
  *
  * @export

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -257,6 +257,12 @@ export interface NovelDetail {
    * @type {string}
    * @memberof NovelDetail
    */
+  /**
+   * 小説の最初の投稿のid
+   * @type {number}
+   * @memberof NovelDetail
+   */
+  firstSentenceId?: number;
   overview?: string;
 }
 /**

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -424,6 +424,12 @@ export interface Sentence {
    */
   evaluationStayCount?: number;
   /**
+   * 投稿に対するログインユーザーの評価状態
+   * @type {string}
+   * @memberof Sentence
+   */
+  userEvaluation?: SentenceUserEvaluationEnum | null;
+  /**
    * 投稿日時
    * @type {string}
    * @memberof Sentence
@@ -436,6 +442,16 @@ export interface Sentence {
    */
   updatedAt?: string;
 }
+
+export const SentenceUserEvaluationEnum = {
+  Good: "good",
+  Bad: "bad",
+  Stay: "stay",
+} as const;
+
+export type SentenceUserEvaluationEnum =
+  (typeof SentenceUserEvaluationEnum)[keyof typeof SentenceUserEvaluationEnum];
+
 /**
  *
  * @export

--- a/src/components/buttonicon/GoodButton.tsx
+++ b/src/components/buttonicon/GoodButton.tsx
@@ -1,17 +1,21 @@
 import React from 'react';
 import SentimentSatisfiedAltIcon from '@mui/icons-material/SentimentSatisfiedAlt';
 
-interface ThumbUpButtonProps {
+interface GoodButtonProps {
   evaluationGoodCount: number;
   isEvaluated: boolean;
   disabled?: boolean;
+  isGoodEvaluated: boolean;
+  setIsGoodEvaluated: React.Dispatch<React.SetStateAction<boolean>>;
   onClick: () => void;
 }
 
-const ThumbUpButton: React.FC<ThumbUpButtonProps> = ({
+const GoodButton: React.FC<GoodButtonProps> = ({
   evaluationGoodCount,
   isEvaluated,
   disabled = false,
+  isGoodEvaluated,
+  setIsGoodEvaluated,
   onClick,
 }) => {
   return (
@@ -31,4 +35,4 @@ const ThumbUpButton: React.FC<ThumbUpButtonProps> = ({
   );
 };
 
-export default ThumbUpButton;
+export default GoodButton;

--- a/src/components/buttonicon/GoodButton.tsx
+++ b/src/components/buttonicon/GoodButton.tsx
@@ -5,8 +5,6 @@ interface GoodButtonProps {
   evaluationGoodCount: number;
   isEvaluated: boolean;
   disabled?: boolean;
-  isGoodEvaluated: boolean;
-  setIsGoodEvaluated: React.Dispatch<React.SetStateAction<boolean>>;
   onClick: () => void;
 }
 
@@ -14,8 +12,6 @@ const GoodButton: React.FC<GoodButtonProps> = ({
   evaluationGoodCount,
   isEvaluated,
   disabled = false,
-  isGoodEvaluated,
-  setIsGoodEvaluated,
   onClick,
 }) => {
   return (

--- a/src/components/buttonicon/StayButton.tsx
+++ b/src/components/buttonicon/StayButton.tsx
@@ -4,8 +4,6 @@ interface StayButtonProps {
   evaluationStayCount: number;
   isEvaluated: boolean;
   disabled?: boolean;
-  isStayEvaluated: boolean;
-  setIsStayEvaluated: React.Dispatch<React.SetStateAction<boolean>>;
   onClick?: () => void;
 }
 
@@ -13,8 +11,6 @@ const StayButton: React.FC<StayButtonProps> = ({
   evaluationStayCount,
   isEvaluated,
   disabled = false,
-  isStayEvaluated,
-  setIsStayEvaluated,
   onClick,
 }) => {
 

--- a/src/components/buttonicon/StayButton.tsx
+++ b/src/components/buttonicon/StayButton.tsx
@@ -1,75 +1,26 @@
-import React, { useRef } from 'react';
+import React from 'react';
 import SentimentVeryDissatisfiedIcon from '@mui/icons-material/SentimentVeryDissatisfied';
-import { EvaluationsApi, EvaluateSentence } from '../../api/api';
-import { axiosConfig } from '../../axiosConfig';
-
 interface StayButtonProps {
   evaluationStayCount: number;
-  setEvaluationStayCount: React.Dispatch<React.SetStateAction<number>>;
   isEvaluated: boolean;
   disabled?: boolean;
-  sentenceId: number;
-  onEvaluationSuccess?: () => void;
   isStayEvaluated: boolean;
   setIsStayEvaluated: React.Dispatch<React.SetStateAction<boolean>>;
+  onClick?: () => void;
 }
 
 const StayButton: React.FC<StayButtonProps> = ({
   evaluationStayCount,
-  setEvaluationStayCount,
   isEvaluated,
   disabled = false,
-  sentenceId,
-  onEvaluationSuccess,
   isStayEvaluated,
   setIsStayEvaluated,
+  onClick,
 }) => {
-  const busyRef = useRef(false); // 再入防止
-  const abortRef = useRef<AbortController | null>(null);
-
-  const handleClick = async () => {
-    if (busyRef.current || disabled) return; // 連打無視
-    busyRef.current = true;
-
-    // 既存リクエストがあれば中断（任意）
-    abortRef.current?.abort();
-    const ac = new AbortController();
-    abortRef.current = ac;
-
-    try {
-      const evaluationsApi = new EvaluationsApi(axiosConfig);
-      const evaluateSentence: EvaluateSentence = {
-        sentenceId: sentenceId,
-        evaluation: 'stay',
-      };
-
-      const response = await evaluationsApi.evaluateSentence(evaluateSentence);
-      if (response?.data) {
-        setEvaluationStayCount(
-          response.data.evaluationStayCount || evaluationStayCount + 1,
-        );
-      } else {
-        setEvaluationStayCount(evaluationStayCount + 1);
-      }
-
-      // 評価成功時に親コンポーネントに通知
-      if (onEvaluationSuccess) {
-        onEvaluationSuccess();
-      }
-    } catch (error) {
-      if ((error as any).name !== 'AbortError') {
-        console.error('評価エラー:', error);
-        // エラー時はローカルでカウント更新
-        setEvaluationStayCount(evaluationStayCount + 1);
-      }
-    } finally {
-      busyRef.current = false;
-    }
-  };
 
   return (
     <div
-      onClick={handleClick}
+      onClick={onClick}
       style={{
         display: 'flex',
         alignItems: 'center',

--- a/src/components/buttonicon/StayButton.tsx
+++ b/src/components/buttonicon/StayButton.tsx
@@ -13,7 +13,6 @@ const StayButton: React.FC<StayButtonProps> = ({
   disabled = false,
   onClick,
 }) => {
-
   return (
     <div
       onClick={onClick}

--- a/src/components/buttonicon/StayButton.tsx
+++ b/src/components/buttonicon/StayButton.tsx
@@ -3,22 +3,26 @@ import SentimentVeryDissatisfiedIcon from '@mui/icons-material/SentimentVeryDiss
 import { EvaluationsApi, EvaluateSentence } from '../../api/api';
 import { axiosConfig } from '../../axiosConfig';
 
-interface NextPlanButtonProps {
+interface StayButtonProps {
   evaluationStayCount: number;
   setEvaluationStayCount: React.Dispatch<React.SetStateAction<number>>;
   isEvaluated: boolean;
   disabled?: boolean;
   sentenceId: number;
   onEvaluationSuccess?: () => void;
+  isStayEvaluated: boolean;
+  setIsStayEvaluated: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-const NextPlanButton: React.FC<NextPlanButtonProps> = ({
+const StayButton: React.FC<StayButtonProps> = ({
   evaluationStayCount,
   setEvaluationStayCount,
   isEvaluated,
   disabled = false,
   sentenceId,
   onEvaluationSuccess,
+  isStayEvaluated,
+  setIsStayEvaluated,
 }) => {
   const busyRef = useRef(false); // 再入防止
   const abortRef = useRef<AbortController | null>(null);
@@ -82,4 +86,4 @@ const NextPlanButton: React.FC<NextPlanButtonProps> = ({
   );
 };
 
-export default NextPlanButton;
+export default StayButton;

--- a/src/components/novelCard/SentenceCard.tsx
+++ b/src/components/novelCard/SentenceCard.tsx
@@ -115,6 +115,53 @@ const SentenceCard = ({
     }
   };
 
+  // Stay評価ボタンのクリック処理
+  const handleStayCountClick = async (): Promise<void> => {
+    if (busyRef.current || !canEvaluate) return;
+    const sentenceId = sentence.sentenceId;
+    if (!sentenceId) {
+      console.warn('sentenceが評価できません: sentenceIdがありません');
+      return;
+    }
+    if (busyRef.current) return;
+    busyRef.current = true;
+    setIsEvaluating(true);
+    abortRef.current?.abort();
+    const ac = new AbortController();
+    abortRef.current = ac;
+    const currentRequestId = ++requestIdRef.current;
+    try {
+      const evaluateSentence: EvaluateSentence = {
+        sentenceId,
+        evaluation: 'stay',
+      };
+      const response = await evaluationsApi.evaluateSentence(evaluateSentence);
+      if (currentRequestId === requestIdRef.current) {
+        const serverStayCount = response?.data?.evaluationStayCount;
+        if (typeof serverStayCount === 'number') {
+          setLocalStayCount(serverStayCount);
+          if (onEvaluationSuccess) {
+            onEvaluationSuccess();
+          }
+        } else {
+          console.warn('評価エラー: evaluationStayCount is not a number');
+        }
+      }
+    } catch (error) {
+      if (
+        currentRequestId === requestIdRef.current &&
+        (error as any).name !== 'AbortError'
+      ) {
+        console.error('評価エラー:', error);
+      }
+    } finally {
+      if (currentRequestId === requestIdRef.current) {
+        setIsEvaluating(false);
+        busyRef.current = false;
+      }
+    }
+  };
+
   return (
     <Box
       component='div'
@@ -183,13 +230,11 @@ const SentenceCard = ({
         />
         <StayButton
           evaluationStayCount={localStayCount}
-          setEvaluationStayCount={setLocalStayCount}
           isEvaluated={isStayEvaluated}
-          sentenceId={sentence.sentenceId || 0}
           disabled={!canEvaluate || isEvaluating}
-          onEvaluationSuccess={onEvaluationSuccess}
           isStayEvaluated={isStayEvaluated}
           setIsStayEvaluated={setIsStayEvaluated}
+          onClick={handleStayCountClick}
         />
       </Box>
     </Box>

--- a/src/components/novelCard/SentenceCard.tsx
+++ b/src/components/novelCard/SentenceCard.tsx
@@ -47,19 +47,23 @@ const SentenceCard = ({
   const requestIdRef = useRef<number>(0); // リクエストIDで最新のリクエストのみ処理
 
   // 評価状態を取得
+  // TODO：評価状態を取得はフロントではなくバック側で行う必要がありそう
+  // ここでsentensecApiを何度も叩いている（main、親、兄弟、子すべて）
+  // レスポンスに評価状態も含まれていないため無意味な通信になっている
   useEffect(() => {
-    const fetchEvaluation = async () => {
-      if (!getSentenceEvaluation || !sentence.sentenceId) return;
 
-      try {
-        const evalData = await getSentenceEvaluation(sentence.sentenceId);
-        setIsGoodEvaluated(evalData.isGoodEvaluated);
-        setIsStayEvaluated(evalData.isStayEvaluated);
-      } catch (error) {
-        console.error('Error fetching evaluation:', error);
-      }
-    };
-    fetchEvaluation();
+    // const fetchEvaluation = async () => {
+    //   if (!getSentenceEvaluation || !sentence.sentenceId) return;
+
+    //   try {
+    //     const evalData = await getSentenceEvaluation(sentence.sentenceId);
+    //     setIsGoodEvaluated(evalData.isGoodEvaluated);
+    //     setIsStayEvaluated(evalData.isStayEvaluated);
+    //   } catch (error) {
+    //     console.error('Error fetching evaluation:', error);
+    //   }
+    // };
+    // fetchEvaluation();
   }, [sentence.sentenceId, getSentenceEvaluation]);
 
   const evaluationsApi = new EvaluationsApi(axiosConfig);

--- a/src/components/novelCard/SentenceCard.tsx
+++ b/src/components/novelCard/SentenceCard.tsx
@@ -47,21 +47,12 @@ const SentenceCard = ({
   const requestIdRef = useRef<number>(0); // リクエストIDで最新のリクエストのみ処理
 
   // 評価状態を取得
-  // TODO：評価状態を取得はフロントではなくバック側で行う必要がありそう
-  // ここでsentensecApiを何度も叩いている（main、親、兄弟、子すべて）
-  // レスポンスに評価状態も含まれていないため無意味な通信になっている
   useEffect(() => {
-    // const fetchEvaluation = async () => {
-    //   if (!getSentenceEvaluation || !sentence.sentenceId) return;
-    //   try {
-    //     const evalData = await getSentenceEvaluation(sentence.sentenceId);
-    //     setIsGoodEvaluated(evalData.isGoodEvaluated);
-    //     setIsStayEvaluated(evalData.isStayEvaluated);
-    //   } catch (error) {
-    //     console.error('Error fetching evaluation:', error);
-    //   }
-    // };
-    // fetchEvaluation();
+    if (sentence.userEvaluation) {
+      setIsGoodEvaluated(sentence.userEvaluation === 'good');
+      setIsStayEvaluated(sentence.userEvaluation === 'stay');
+      return;
+    }
   }, [sentence.sentenceId, getSentenceEvaluation]);
 
   const evaluationsApi = new EvaluationsApi(axiosConfig);

--- a/src/components/novelCard/SentenceCard.tsx
+++ b/src/components/novelCard/SentenceCard.tsx
@@ -51,10 +51,8 @@ const SentenceCard = ({
   // ここでsentensecApiを何度も叩いている（main、親、兄弟、子すべて）
   // レスポンスに評価状態も含まれていないため無意味な通信になっている
   useEffect(() => {
-
     // const fetchEvaluation = async () => {
     //   if (!getSentenceEvaluation || !sentence.sentenceId) return;
-
     //   try {
     //     const evalData = await getSentenceEvaluation(sentence.sentenceId);
     //     setIsGoodEvaluated(evalData.isGoodEvaluated);

--- a/src/components/novelCard/SentenceCard.tsx
+++ b/src/components/novelCard/SentenceCard.tsx
@@ -56,67 +56,9 @@ const SentenceCard = ({
   }, [sentence.sentenceId, getSentenceEvaluation]);
 
   const evaluationsApi = new EvaluationsApi(axiosConfig);
-  const handleGoodCountClick = async (): Promise<void> => {
-    if (busyRef.current || !canEvaluate) return; // 連打無視
 
-    const sentenceId = sentence.sentenceId;
-    if (!sentenceId) {
-      console.warn('sentenceが評価できません: sentenceIdがありません');
-      return;
-    }
-
-    // アトミックな操作でbusyフラグを設定
-    if (busyRef.current) return; // 二重チェック
-    busyRef.current = true;
-    setIsEvaluating(true);
-
-    // 既存リクエストがあれば中断
-    abortRef.current?.abort();
-    const ac = new AbortController();
-    abortRef.current = ac;
-
-    // リクエストIDをインクリメント（最新のリクエストのみ処理）
-    const currentRequestId = ++requestIdRef.current;
-
-    try {
-      const evaluateSentence: EvaluateSentence = {
-        sentenceId,
-        evaluation: 'good',
-      };
-
-      const response = await evaluationsApi.evaluateSentence(evaluateSentence);
-
-      // 最新のリクエストかどうかをチェック
-      if (currentRequestId === requestIdRef.current) {
-        const serverGoodCount = response?.data?.evaluationGoodCount;
-        if (typeof serverGoodCount === 'number') {
-          setLocalGoodCount(serverGoodCount);
-          if (onEvaluationSuccess) {
-            onEvaluationSuccess();
-          }
-        } else {
-          console.warn('評価エラー: evaluationGoodCount is not a number');
-        }
-      }
-    } catch (error) {
-      // 最新のリクエストかつAbortErrorでない場合のみエラー処理
-      if (
-        currentRequestId === requestIdRef.current &&
-        (error as any).name !== 'AbortError'
-      ) {
-        console.error('評価エラー:', error);
-      }
-    } finally {
-      // 最新のリクエストの場合のみ状態をリセット
-      if (currentRequestId === requestIdRef.current) {
-        setIsEvaluating(false);
-        busyRef.current = false;
-      }
-    }
-  };
-
-  // Stay評価ボタンのクリック処理
-  const handleStayCountClick = async (): Promise<void> => {
+  // Good/Stay評価ボタンのクリック処理
+  const handleEvaluationClick = async (evaluationType: 'good' | 'stay'): Promise<void> => {
     if (busyRef.current || !canEvaluate) return;
     const sentenceId = sentence.sentenceId;
     if (!sentenceId) {
@@ -133,19 +75,16 @@ const SentenceCard = ({
     try {
       const evaluateSentence: EvaluateSentence = {
         sentenceId,
-        evaluation: 'stay',
+        evaluation: evaluationType,
       };
       const response = await evaluationsApi.evaluateSentence(evaluateSentence);
       if (currentRequestId === requestIdRef.current) {
-        const serverStayCount = response?.data?.evaluationStayCount;
-        if (typeof serverStayCount === 'number') {
-          setLocalStayCount(serverStayCount);
-          if (onEvaluationSuccess) {
-            onEvaluationSuccess();
-          }
-        } else {
-          console.warn('評価エラー: evaluationStayCount is not a number');
-        }
+        const { evaluationGoodCount, evaluationStayCount, userEvaluation } = response?.data || {};
+        if (typeof evaluationGoodCount === 'number') setLocalGoodCount(evaluationGoodCount);
+        if (typeof evaluationStayCount === 'number') setLocalStayCount(evaluationStayCount);
+        setIsGoodEvaluated(userEvaluation === 'good');
+        setIsStayEvaluated(userEvaluation === 'stay');
+        if (onEvaluationSuccess) onEvaluationSuccess();
       }
     } catch (error) {
       if (
@@ -223,18 +162,14 @@ const SentenceCard = ({
         <GoodButton
           evaluationGoodCount={localGoodCount}
           isEvaluated={isGoodEvaluated}
-          onClick={handleGoodCountClick}
+          onClick={() => handleEvaluationClick('good')}
           disabled={!canEvaluate || isEvaluating}
-          isGoodEvaluated={isGoodEvaluated}
-          setIsGoodEvaluated={setIsGoodEvaluated}
         />
         <StayButton
           evaluationStayCount={localStayCount}
           isEvaluated={isStayEvaluated}
           disabled={!canEvaluate || isEvaluating}
-          isStayEvaluated={isStayEvaluated}
-          setIsStayEvaluated={setIsStayEvaluated}
-          onClick={handleStayCountClick}
+          onClick={() => handleEvaluationClick('stay')}
         />
       </Box>
     </Box>

--- a/src/components/novelCard/SentenceCard.tsx
+++ b/src/components/novelCard/SentenceCard.tsx
@@ -48,11 +48,8 @@ const SentenceCard = ({
 
   // 評価状態を取得
   useEffect(() => {
-    if (sentence.userEvaluation) {
-      setIsGoodEvaluated(sentence.userEvaluation === 'good');
-      setIsStayEvaluated(sentence.userEvaluation === 'stay');
-      return;
-    }
+    setIsGoodEvaluated(sentence.userEvaluation === 'good');
+    setIsStayEvaluated(sentence.userEvaluation === 'stay');
   }, [sentence.sentenceId, getSentenceEvaluation]);
 
   const evaluationsApi = new EvaluationsApi(axiosConfig);

--- a/src/components/novelCard/SentenceCard.tsx
+++ b/src/components/novelCard/SentenceCard.tsx
@@ -1,7 +1,7 @@
 import { useRef, useState, useEffect } from 'react';
 import { Avatar, Box, Typography } from '@mui/material';
-import ThumbUpButton from '../buttonicon/ThumbsUpButton';
-import NextPlanButton from '../buttonicon/NextPlanButton';
+import GoodButton from '../buttonicon/GoodButton';
+import StayButton from '../buttonicon/StayButton';
 import { EvaluationsApi, EvaluateSentence, Sentence } from '../../api/api';
 import { axiosConfig } from '../../axiosConfig';
 
@@ -173,19 +173,23 @@ const SentenceCard = ({
           backgroundColor: 'transparent',
         }}
       >
-        <ThumbUpButton
+        <GoodButton
           evaluationGoodCount={localGoodCount}
           isEvaluated={isGoodEvaluated}
           onClick={handleGoodCountClick}
           disabled={!canEvaluate || isEvaluating}
+          isGoodEvaluated={isGoodEvaluated}
+          setIsGoodEvaluated={setIsGoodEvaluated}
         />
-        <NextPlanButton
+        <StayButton
           evaluationStayCount={localStayCount}
           setEvaluationStayCount={setLocalStayCount}
           isEvaluated={isStayEvaluated}
           sentenceId={sentence.sentenceId || 0}
           disabled={!canEvaluate || isEvaluating}
           onEvaluationSuccess={onEvaluationSuccess}
+          isStayEvaluated={isStayEvaluated}
+          setIsStayEvaluated={setIsStayEvaluated}
         />
       </Box>
     </Box>

--- a/src/components/novelCard/SentenceCard.tsx
+++ b/src/components/novelCard/SentenceCard.tsx
@@ -58,7 +58,9 @@ const SentenceCard = ({
   const evaluationsApi = new EvaluationsApi(axiosConfig);
 
   // Good/Stay評価ボタンのクリック処理
-  const handleEvaluationClick = async (evaluationType: 'good' | 'stay'): Promise<void> => {
+  const handleEvaluationClick = async (
+    evaluationType: 'good' | 'stay',
+  ): Promise<void> => {
     if (busyRef.current || !canEvaluate) return;
     const sentenceId = sentence.sentenceId;
     if (!sentenceId) {
@@ -79,9 +81,12 @@ const SentenceCard = ({
       };
       const response = await evaluationsApi.evaluateSentence(evaluateSentence);
       if (currentRequestId === requestIdRef.current) {
-        const { evaluationGoodCount, evaluationStayCount, userEvaluation } = response?.data || {};
-        if (typeof evaluationGoodCount === 'number') setLocalGoodCount(evaluationGoodCount);
-        if (typeof evaluationStayCount === 'number') setLocalStayCount(evaluationStayCount);
+        const { evaluationGoodCount, evaluationStayCount, userEvaluation } =
+          response?.data || {};
+        if (typeof evaluationGoodCount === 'number')
+          setLocalGoodCount(evaluationGoodCount);
+        if (typeof evaluationStayCount === 'number')
+          setLocalStayCount(evaluationStayCount);
         setIsGoodEvaluated(userEvaluation === 'good');
         setIsStayEvaluated(userEvaluation === 'stay');
         if (onEvaluationSuccess) onEvaluationSuccess();

--- a/src/features/NovelInfo/index.tsx
+++ b/src/features/NovelInfo/index.tsx
@@ -51,11 +51,7 @@ export const NovelInfo = ({ open, onClose, titleId }: NovelInfoProps) => {
   }, [titleId]);
 
   const handleReadMore = () => {
-    if (
-      !novel ||
-      novel.titleId == null ||
-      novel.firstSentenceId == null
-    ) {
+    if (!novel || novel.titleId == null || novel.firstSentenceId == null) {
       console.error('小説情報が正しく取得できていません');
       setHasError(true);
       return;

--- a/src/features/NovelInfo/index.tsx
+++ b/src/features/NovelInfo/index.tsx
@@ -51,7 +51,16 @@ export const NovelInfo = ({ open, onClose, titleId }: NovelInfoProps) => {
   }, [titleId]);
 
   const handleReadMore = () => {
-    navigate('/novelView'); // novelViewページに遷移
+    if (
+      !novel ||
+      novel.titleId == null ||
+      novel.firstSentenceId == null
+    ) {
+      console.error('小説情報が正しく取得できていません');
+      setHasError(true);
+      return;
+    }
+    navigate('/novelView/' + novel.titleId + '/' + novel.firstSentenceId);
   };
 
   if (loading) {

--- a/src/features/NovelInfo/mocks/handlers.ts
+++ b/src/features/NovelInfo/mocks/handlers.ts
@@ -26,6 +26,7 @@ export const novelInfoHandlers = [
       createdAt: '2024-01-01T00:00:00Z',
       authorUserId: Number(titleId),
       evaluationGoodCount: 50 * Number(titleId),
+      firstSentenceId: 1,
     };
 
     return HttpResponse.json(response);

--- a/src/features/NovelList/mocks/handlers.ts
+++ b/src/features/NovelList/mocks/handlers.ts
@@ -60,6 +60,7 @@ export const novelListHandlers = [
       profileIconImage: '/path/to/avatar.jpg',
       evaluationGoodCount: 0,
       evaluationStayCount: 0,
+      userEvaluation: null,
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
     };

--- a/src/features/NovelList/mocks/handlers.ts
+++ b/src/features/NovelList/mocks/handlers.ts
@@ -74,12 +74,10 @@ export const novelListHandlers = [
 
     // 評価を処理（実際の実装ではデータベースに保存）
     const mockEvaluation = {
-      evaluationId: Math.floor(Math.random() * 10000) + 1000,
       sentenceId: data.sentenceId,
-      evaluation: data.evaluation,
-      userId: mockUser.userId,
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
+      evaluationGoodCount: data.evaluation === 'good' ? 1 : 0,
+      evaluationStayCount: data.evaluation === 'stay' ? 1 : 0,
+      userEvaluation: data.evaluation,
     };
 
     return HttpResponse.json(mockEvaluation, { status: 201 });

--- a/src/features/NovelView/NovelViewContainer.tsx
+++ b/src/features/NovelView/NovelViewContainer.tsx
@@ -17,18 +17,21 @@ export const NovelViewContainer = () => {
 
   // titleId, sentenceIdが未定義または数字でない場合はエラー
   if (titleId === undefined || sentenceId === undefined) {
-    console.error('Error: URLパラメータが不足しています（titleId, sentenceId）');
+    console.error(
+      'Error: URLパラメータが不足しています（titleId, sentenceId）',
+    );
     return (
-      <div>
-        エラー: URLパラメータが不足しています（titleId, sentenceId）
-      </div>
+      <div>エラー: URLパラメータが不足しています（titleId, sentenceId）</div>
     );
   }
   if (!/^\d+$/.test(titleId) || !/^\d+$/.test(sentenceId)) {
-    console.error('Error: URLパラメータが不正です（titleId, sentenceId は数字である必要があります）');
+    console.error(
+      'Error: URLパラメータが不正です（titleId, sentenceId は数字である必要があります）',
+    );
     return (
       <div>
-        エラー: URLパラメータが不正です（titleId, sentenceId は数字である必要があります）
+        エラー: URLパラメータが不正です（titleId, sentenceId
+        は数字である必要があります）
       </div>
     );
   }
@@ -72,6 +75,7 @@ export const NovelViewContainer = () => {
           profileIconImage: apiSentence.profileIconImage,
           evaluationGoodCount: apiSentence.evaluationGoodCount,
           evaluationStayCount: apiSentence.evaluationStayCount,
+          userEvaluation: apiSentence.userEvaluation,
           createdAt: apiSentence.createdAt,
           updatedAt: apiSentence.updatedAt,
         });
@@ -156,6 +160,7 @@ export const NovelViewContainer = () => {
           profileIconImage: apiSentence.profileIconImage || '',
           evaluationGoodCount: apiSentence.evaluationGoodCount || 0,
           evaluationStayCount: apiSentence.evaluationStayCount || 0,
+          userEvaluation: apiSentence.userEvaluation || null,
           createdAt: apiSentence.createdAt,
           updatedAt: apiSentence.updatedAt,
         });
@@ -267,6 +272,7 @@ export const NovelViewContainer = () => {
           profileIconImage: apiSentence.profileIconImage || '',
           evaluationGoodCount: apiSentence.evaluationGoodCount || 0,
           evaluationStayCount: apiSentence.evaluationStayCount || 0,
+          userEvaluation: apiSentence.userEvaluation || null,
           createdAt: apiSentence.createdAt,
           updatedAt: apiSentence.updatedAt,
         });

--- a/src/features/NovelView/NovelViewContainer.tsx
+++ b/src/features/NovelView/NovelViewContainer.tsx
@@ -53,173 +53,67 @@ export const NovelViewContainer = () => {
   const [originalMainSentence, setOriginalMainSentence] =
     useState<Sentence | null>(null);
 
+  // Sentence型への変換
+  const convertToSentence = (apiSentence: any): Sentence => ({
+    sentenceId: apiSentence.sentenceId,
+    sentence: apiSentence.sentence,
+    sentenceUserId: apiSentence.sentenceUserId,
+    sentencePenName: apiSentence.sentencePenName,
+    profileIconImage: apiSentence.profileIconImage || '',
+    evaluationGoodCount: apiSentence.evaluationGoodCount || 0,
+    evaluationStayCount: apiSentence.evaluationStayCount || 0,
+    userEvaluation: apiSentence.userEvaluation || null,
+    createdAt: apiSentence.createdAt,
+    updatedAt: apiSentence.updatedAt,
+  });
+
+  // 投稿データ取得処理
+  const fetchSentenceData = async (targetId: number) => {
+    try {
+      const response = await sentencesApi.getSentenceById(targetId);
+      if (!response || !response.data) {
+        throw new Error('No data received from API');
+      }
+      const data = response.data;
+
+      if (data.main) setMainPanel([convertToSentence(data.main)]);
+      if (data.parent) setParentPanel([convertToSentence(data.parent)]);
+      else setParentPanel([]);
+      if (data.parallels && data.parallels.length > 0) setParallelSentences(data.parallels.map(convertToSentence));
+      else setParallelSentences([]);
+      if (data.children && data.children.length > 0) setChildrenPanel(data.children.map(convertToSentence));
+      else setChildrenPanel([]);
+
+      if (data.main) {
+        const currentMainSentence = convertToSentence(data.main);
+        setOriginalMainSentence(currentMainSentence);
+        if (data.parallels) {
+          const parallels = data.parallels.map(convertToSentence);
+          const currentIndex = parallels.findIndex((p: Sentence) => p.sentenceId === targetId);
+          currentParallelIndexRef.current = currentIndex >= 0 ? currentIndex : -1;
+        }
+        setHasMainPanelEvaluation(false);
+      }
+    } catch (error) {
+      console.error('Error fetching sentence data:', error);
+      setMainPanel([]);
+      setParentPanel([]);
+      setChildrenPanel([]);
+      setParallelSentences([]);
+      setOriginalMainSentence(null);
+      setHasMainPanelEvaluation(false);
+    }
+  };
+
   // URLが変更されたときにデータを更新（初回も必ず実行）
   useEffect(() => {
     const targetId = parseInt(sentenceId!, 10);
-
-    // APIから投稿データを取得
-    const fetchSentenceData = async () => {
-      try {
-        const response = await sentencesApi.getSentenceById(targetId);
-        if (!response || !response.data) {
-          throw new Error('No data received from API');
-        }
-        const data = response.data;
-
-        // API レスポンスを内部のSentence型に変換
-        const convertToSentence = (apiSentence: any): Sentence => ({
-          sentenceId: apiSentence.sentenceId,
-          sentence: apiSentence.sentence,
-          sentenceUserId: apiSentence.sentenceUserId,
-          sentencePenName: apiSentence.sentencePenName,
-          profileIconImage: apiSentence.profileIconImage,
-          evaluationGoodCount: apiSentence.evaluationGoodCount,
-          evaluationStayCount: apiSentence.evaluationStayCount,
-          userEvaluation: apiSentence.userEvaluation,
-          createdAt: apiSentence.createdAt,
-          updatedAt: apiSentence.updatedAt,
-        });
-
-        // メイン、親、パラレル、子の投稿を設定
-        if (data.main) {
-          setMainPanel([convertToSentence(data.main)]);
-        }
-        if (data.parent) {
-          setParentPanel([convertToSentence(data.parent)]);
-        } else {
-          setParentPanel([]);
-        }
-        if (data.parallels && data.parallels.length > 0) {
-          setParallelSentences(data.parallels.map(convertToSentence));
-        } else {
-          setParallelSentences([]);
-        }
-        if (data.children && data.children.length > 0) {
-          setChildrenPanel(data.children.map(convertToSentence));
-        } else {
-          setChildrenPanel([]);
-        }
-
-        // パラレル投稿の初期設定
-        if (data.main) {
-          const currentMainSentence = convertToSentence(data.main);
-          setOriginalMainSentence(currentMainSentence);
-
-          // 現在のsentenceがパラレル投稿の中にある場合、そのインデックスを設定
-          if (data.parallels) {
-            const parallels = data.parallels.map(convertToSentence);
-            const currentIndex = parallels.findIndex(
-              (p: Sentence) => p.sentenceId === targetId,
-            );
-
-            if (currentIndex >= 0) {
-              currentParallelIndexRef.current = currentIndex;
-            } else {
-              currentParallelIndexRef.current = -1;
-            }
-          }
-
-          // MainPanelの評価状態を設定
-          setHasMainPanelEvaluation(false);
-        }
-      } catch (error) {
-        console.error('Error fetching sentence data:', error);
-        // エラー時は空のデータを設定
-        setMainPanel([]);
-        setParentPanel([]);
-        setChildrenPanel([]);
-        setParallelSentences([]);
-        setOriginalMainSentence(null);
-        setHasMainPanelEvaluation(false);
-      }
-    };
-
-    fetchSentenceData();
+    fetchSentenceData(targetId);
   }, [sentenceId]);
 
   // 画面更新用の関数
   const handleRefresh = useCallback(() => {
-    // 現在のデータを再取得する処理
-    const targetId = currentSentenceIdRef.current;
-
-    // データの再取得処理（既存のfetchSentenceDataのロジックを再利用）
-    const fetchSentenceData = async () => {
-      try {
-        const response = await sentencesApi.getSentenceById(targetId);
-        if (!response || !response.data) {
-          throw new Error('No data received from API');
-        }
-        const data = response.data;
-
-        // API レスポンスを内部のSentence型に変換
-        const convertToSentence = (apiSentence: any): Sentence => ({
-          sentenceId: apiSentence.sentenceId,
-          sentence: apiSentence.sentence,
-          sentenceUserId: apiSentence.sentenceUserId,
-          sentencePenName: apiSentence.sentencePenName,
-          profileIconImage: apiSentence.profileIconImage || '',
-          evaluationGoodCount: apiSentence.evaluationGoodCount || 0,
-          evaluationStayCount: apiSentence.evaluationStayCount || 0,
-          userEvaluation: apiSentence.userEvaluation || null,
-          createdAt: apiSentence.createdAt,
-          updatedAt: apiSentence.updatedAt,
-        });
-
-        // メイン、親、パラレル、子の投稿を設定
-        if (data.main) {
-          setMainPanel([convertToSentence(data.main)]);
-        }
-        if (data.parent) {
-          setParentPanel([convertToSentence(data.parent)]);
-        } else {
-          setParentPanel([]);
-        }
-        if (data.parallels && data.parallels.length > 0) {
-          setParallelSentences(data.parallels.map(convertToSentence));
-        } else {
-          setParallelSentences([]);
-        }
-        if (data.children && data.children.length > 0) {
-          setChildrenPanel(data.children.map(convertToSentence));
-        } else {
-          setChildrenPanel([]);
-        }
-
-        // パラレル投稿の初期設定
-        if (data.main) {
-          const currentMainSentence = convertToSentence(data.main);
-          setOriginalMainSentence(currentMainSentence);
-
-          // 現在のsentenceがパラレル投稿の中にある場合、そのインデックスを設定
-          if (data.parallels) {
-            const parallels = data.parallels.map(convertToSentence);
-            const currentIndex = parallels.findIndex(
-              (p: Sentence) => p.sentenceId === targetId,
-            );
-
-            if (currentIndex >= 0) {
-              currentParallelIndexRef.current = currentIndex;
-            } else {
-              currentParallelIndexRef.current = -1;
-            }
-          }
-
-          // MainPanelの評価状態を設定
-          setHasMainPanelEvaluation(false);
-        }
-      } catch (error) {
-        console.error('Error refreshing sentence data:', error);
-        // エラー時は空のデータを設定
-        setMainPanel([]);
-        setParentPanel([]);
-        setChildrenPanel([]);
-        setParallelSentences([]);
-        setOriginalMainSentence(null);
-        setHasMainPanelEvaluation(false);
-      }
-    };
-
-    fetchSentenceData();
+    fetchSentenceData(currentSentenceIdRef.current);
   }, []);
 
   // 評価成功時の処理

--- a/src/features/NovelView/NovelViewContainer.tsx
+++ b/src/features/NovelView/NovelViewContainer.tsx
@@ -76,13 +76,24 @@ export const NovelViewContainer = () => {
       }
       const data = response.data;
 
-      if (data.main) setMainPanel([convertToSentence(data.main)]);
-      if (data.parent) setParentPanel([convertToSentence(data.parent)]);
-      else setParentPanel([]);
-      if (data.parallels && data.parallels.length > 0) setParallelSentences(data.parallels.map(convertToSentence));
-      else setParallelSentences([]);
-      if (data.children && data.children.length > 0) setChildrenPanel(data.children.map(convertToSentence));
-      else setChildrenPanel([]);
+      if (data.main) {
+        setMainPanel([convertToSentence(data.main)]);
+      }
+      if (data.parent) {
+        setParentPanel([convertToSentence(data.parent)]);
+      } else {
+        setParentPanel([]);
+      }
+      if (data.parallels && data.parallels.length > 0) {
+        setParallelSentences(data.parallels.map(convertToSentence));
+      } else {
+        setParallelSentences([]);
+      }
+      if (data.children && data.children.length > 0) {
+        setChildrenPanel(data.children.map(convertToSentence));
+      } else {
+        setChildrenPanel([]);
+      }
 
       if (data.main) {
         const currentMainSentence = convertToSentence(data.main);

--- a/src/features/NovelView/NovelViewContainer.tsx
+++ b/src/features/NovelView/NovelViewContainer.tsx
@@ -7,20 +7,31 @@ import { axiosConfig } from '../../axiosConfig';
 
 const sentencesApi = new SentencesApi(axiosConfig);
 
-// 初期読み込み用のセンテンスID設定
-const INITIAL_SENTENCE_ID = 5;
-
 export const NovelViewContainer = () => {
   // URLパラメータを取得
-  const { titleId: urlTitleId, sentenceId: urlSentenceId } = useParams<{
-    titleId: string;
-    sentenceId: string;
+  const { titleId, sentenceId } = useParams<{
+    titleId: string | undefined;
+    sentenceId: string | undefined;
   }>();
   const navigate = useNavigate();
 
-  // デフォルト値を設定
-  const titleId = urlTitleId || '1';
-  const sentenceId = urlSentenceId || INITIAL_SENTENCE_ID.toString();
+  // titleId, sentenceIdが未定義または数字でない場合はエラー
+  if (titleId === undefined || sentenceId === undefined) {
+    console.error('Error: URLパラメータが不足しています（titleId, sentenceId）');
+    return (
+      <div>
+        エラー: URLパラメータが不足しています（titleId, sentenceId）
+      </div>
+    );
+  }
+  if (!/^\d+$/.test(titleId) || !/^\d+$/.test(sentenceId)) {
+    console.error('Error: URLパラメータが不正です（titleId, sentenceId は数字である必要があります）');
+    return (
+      <div>
+        エラー: URLパラメータが不正です（titleId, sentenceId は数字である必要があります）
+      </div>
+    );
+  }
 
   // MainPanelの評価状態を追跡
   const [hasMainPanelEvaluation, setHasMainPanelEvaluation] = useState(false);
@@ -31,9 +42,7 @@ export const NovelViewContainer = () => {
   const [childrenPanel, setChildrenPanel] = useState<Sentence[]>([]);
 
   // 現在のsentenceIdと関連するパラレル投稿の管理
-  const currentSentenceIdRef = useRef<number>(
-    sentenceId ? parseInt(sentenceId, 10) : INITIAL_SENTENCE_ID,
-  );
+  const currentSentenceIdRef = useRef<number>(parseInt(sentenceId!, 10));
 
   // パラレル投稿管理用の状態
   const currentParallelIndexRef = useRef(0);
@@ -41,92 +50,87 @@ export const NovelViewContainer = () => {
   const [originalMainSentence, setOriginalMainSentence] =
     useState<Sentence | null>(null);
 
-  // URLが変更されたときにデータを更新
+  // URLが変更されたときにデータを更新（初回も必ず実行）
   useEffect(() => {
-    const targetId = sentenceId
-      ? parseInt(sentenceId, 10)
-      : INITIAL_SENTENCE_ID;
-    if (targetId !== currentSentenceIdRef.current) {
-      currentSentenceIdRef.current = targetId;
+    const targetId = parseInt(sentenceId!, 10);
 
-      // APIから投稿データを取得
-      const fetchSentenceData = async () => {
-        try {
-          const response = await sentencesApi.getSentenceById(targetId);
-          if (!response || !response.data) {
-            throw new Error('No data received from API');
-          }
-          const data = response.data;
+    // APIから投稿データを取得
+    const fetchSentenceData = async () => {
+      try {
+        const response = await sentencesApi.getSentenceById(targetId);
+        if (!response || !response.data) {
+          throw new Error('No data received from API');
+        }
+        const data = response.data;
 
-          // API レスポンスを内部のSentence型に変換
-          const convertToSentence = (apiSentence: any): Sentence => ({
-            sentenceId: apiSentence.sentenceId,
-            sentence: apiSentence.sentence,
-            sentenceUserId: apiSentence.sentenceUserId,
-            sentencePenName: apiSentence.sentencePenName,
-            profileIconImage: apiSentence.profileIconImage,
-            evaluationGoodCount: apiSentence.evaluationGoodCount,
-            evaluationStayCount: apiSentence.evaluationStayCount,
-            createdAt: apiSentence.createdAt,
-            updatedAt: apiSentence.updatedAt,
-          });
+        // API レスポンスを内部のSentence型に変換
+        const convertToSentence = (apiSentence: any): Sentence => ({
+          sentenceId: apiSentence.sentenceId,
+          sentence: apiSentence.sentence,
+          sentenceUserId: apiSentence.sentenceUserId,
+          sentencePenName: apiSentence.sentencePenName,
+          profileIconImage: apiSentence.profileIconImage,
+          evaluationGoodCount: apiSentence.evaluationGoodCount,
+          evaluationStayCount: apiSentence.evaluationStayCount,
+          createdAt: apiSentence.createdAt,
+          updatedAt: apiSentence.updatedAt,
+        });
 
-          // メイン、親、パラレル、子の投稿を設定
-          if (data.main) {
-            setMainPanel([convertToSentence(data.main)]);
-          }
-          if (data.parent) {
-            setParentPanel([convertToSentence(data.parent)]);
-          } else {
-            setParentPanel([]);
-          }
-          if (data.parallels && data.parallels.length > 0) {
-            setParallelSentences(data.parallels.map(convertToSentence));
-          } else {
-            setParallelSentences([]);
-          }
-          if (data.children && data.children.length > 0) {
-            setChildrenPanel(data.children.map(convertToSentence));
-          } else {
-            setChildrenPanel([]);
-          }
-
-          // パラレル投稿の初期設定
-          if (data.main) {
-            const currentMainSentence = convertToSentence(data.main);
-            setOriginalMainSentence(currentMainSentence);
-
-            // 現在のsentenceがパラレル投稿の中にある場合、そのインデックスを設定
-            if (data.parallels) {
-              const parallels = data.parallels.map(convertToSentence);
-              const currentIndex = parallels.findIndex(
-                (p: Sentence) => p.sentenceId === targetId,
-              );
-
-              if (currentIndex >= 0) {
-                currentParallelIndexRef.current = currentIndex;
-              } else {
-                currentParallelIndexRef.current = -1;
-              }
-            }
-
-            // MainPanelの評価状態を設定
-            setHasMainPanelEvaluation(false);
-          }
-        } catch (error) {
-          console.error('Error fetching sentence data:', error);
-          // エラー時は空のデータを設定
-          setMainPanel([]);
+        // メイン、親、パラレル、子の投稿を設定
+        if (data.main) {
+          setMainPanel([convertToSentence(data.main)]);
+        }
+        if (data.parent) {
+          setParentPanel([convertToSentence(data.parent)]);
+        } else {
           setParentPanel([]);
-          setChildrenPanel([]);
+        }
+        if (data.parallels && data.parallels.length > 0) {
+          setParallelSentences(data.parallels.map(convertToSentence));
+        } else {
           setParallelSentences([]);
-          setOriginalMainSentence(null);
+        }
+        if (data.children && data.children.length > 0) {
+          setChildrenPanel(data.children.map(convertToSentence));
+        } else {
+          setChildrenPanel([]);
+        }
+
+        // パラレル投稿の初期設定
+        if (data.main) {
+          const currentMainSentence = convertToSentence(data.main);
+          setOriginalMainSentence(currentMainSentence);
+
+          // 現在のsentenceがパラレル投稿の中にある場合、そのインデックスを設定
+          if (data.parallels) {
+            const parallels = data.parallels.map(convertToSentence);
+            const currentIndex = parallels.findIndex(
+              (p: Sentence) => p.sentenceId === targetId,
+            );
+
+            if (currentIndex >= 0) {
+              currentParallelIndexRef.current = currentIndex;
+            } else {
+              currentParallelIndexRef.current = -1;
+            }
+          }
+
+          // MainPanelの評価状態を設定
           setHasMainPanelEvaluation(false);
         }
-      };
+      } catch (error) {
+        console.error('Error fetching sentence data:', error);
+        // エラー時は空のデータを設定
+        setMainPanel([]);
+        setParentPanel([]);
+        setChildrenPanel([]);
+        setParallelSentences([]);
+        setOriginalMainSentence(null);
+        setHasMainPanelEvaluation(false);
+      }
+    };
 
-      fetchSentenceData();
-    }
+    fetchSentenceData();
   }, [sentenceId]);
 
   // 画面更新用の関数
@@ -367,7 +371,17 @@ export const NovelViewContainer = () => {
   const handleParentClick = useCallback(
     (clickedSentence: any) => {
       // ParentPanelの投稿をクリックしたときは、その投稿をmainに移動
-      navigate(`/novelView/${titleId || '1'}/${clickedSentence.sentenceId}`);
+      if (!titleId) {
+        console.error('Error: titleIdがありません');
+        setMainPanel([]);
+        setParentPanel([]);
+        setChildrenPanel([]);
+        setParallelSentences([]);
+        setOriginalMainSentence(null);
+        setHasMainPanelEvaluation(false);
+        return;
+      }
+      navigate(`/novelView/${titleId}/${clickedSentence.sentenceId}`);
     },
     [navigate, titleId],
   );

--- a/src/features/NovelView/mocks/data.ts
+++ b/src/features/NovelView/mocks/data.ts
@@ -25,6 +25,7 @@ export const mockParentPanel: Sentence[] = [
     profileIconImage: '',
     evaluationGoodCount: 0,
     evaluationStayCount: 0,
+    userEvaluation: null,
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
   },
@@ -39,6 +40,7 @@ export const mockMainPanel: Sentence[] = [
     profileIconImage: '',
     evaluationGoodCount: 0,
     evaluationStayCount: 0,
+    userEvaluation: null,
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
   },
@@ -53,6 +55,7 @@ export const mockChildrenPanel: Sentence[] = [
     profileIconImage: '',
     evaluationGoodCount: 0,
     evaluationStayCount: 0,
+    userEvaluation: null,
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
   },
@@ -66,14 +69,13 @@ export const mockNovelProps = {
   profileIconImage: '',
   evaluationGoodCount: 0,
   evaluationStayCount: 0,
+  userEvaluation: null,
   createdAt: new Date().toISOString(),
   updatedAt: new Date().toISOString(),
   children: mockChildrenPanel,
   parent: mockParentPanel,
   main: mockMainPanel,
 };
-
-
 
 // センテンスの一意のIDを持つデータ
 
@@ -86,6 +88,7 @@ export const sentencesData: Record<number, Sentence> = {
     profileIconImage: 'path/to/image.png',
     evaluationGoodCount: 15,
     evaluationStayCount: 3,
+    userEvaluation: null,
     createdAt: '2024-01-01T00:00:00Z',
     updatedAt: '2024-01-01T00:00:00Z',
   },
@@ -98,6 +101,7 @@ export const sentencesData: Record<number, Sentence> = {
     profileIconImage: 'path/to/image.png',
     evaluationGoodCount: 12,
     evaluationStayCount: 2,
+    userEvaluation: null,
     createdAt: '2024-01-02T00:00:00Z',
     updatedAt: '2024-01-02T00:00:00Z',
   },
@@ -110,6 +114,7 @@ export const sentencesData: Record<number, Sentence> = {
     profileIconImage: 'path/to/image2.png',
     evaluationGoodCount: 8,
     evaluationStayCount: 1,
+    userEvaluation: null,
     createdAt: '2024-01-03T00:00:00Z',
     updatedAt: '2024-01-03T00:00:00Z',
   },
@@ -122,6 +127,7 @@ export const sentencesData: Record<number, Sentence> = {
     profileIconImage: 'path/to/image3.png',
     evaluationGoodCount: 14,
     evaluationStayCount: 4,
+    userEvaluation: null,
     createdAt: '2024-01-04T00:00:00Z',
     updatedAt: '2024-01-04T00:00:00Z',
   },
@@ -134,6 +140,7 @@ export const sentencesData: Record<number, Sentence> = {
     profileIconImage: 'path/to/image4.png',
     evaluationGoodCount: 22,
     evaluationStayCount: 6,
+    userEvaluation: null,
     createdAt: '2024-01-05T00:00:00Z',
     updatedAt: '2024-01-05T00:00:00Z',
   },
@@ -146,6 +153,7 @@ export const sentencesData: Record<number, Sentence> = {
     profileIconImage: 'path/to/image5.png',
     evaluationGoodCount: 18,
     evaluationStayCount: 5,
+    userEvaluation: null,
     createdAt: '2024-01-06T00:00:00Z',
     updatedAt: '2024-01-06T00:00:00Z',
   },
@@ -158,6 +166,7 @@ export const sentencesData: Record<number, Sentence> = {
     profileIconImage: 'path/to/image6.png',
     evaluationGoodCount: 9,
     evaluationStayCount: 2,
+    userEvaluation: null,
     createdAt: '2024-01-07T00:00:00Z',
     updatedAt: '2024-01-07T00:00:00Z',
   },
@@ -170,6 +179,7 @@ export const sentencesData: Record<number, Sentence> = {
     profileIconImage: 'path/to/image7.png',
     evaluationGoodCount: 11,
     evaluationStayCount: 1,
+    userEvaluation: null,
     createdAt: '2024-01-08T00:00:00Z',
     updatedAt: '2024-01-08T00:00:00Z',
   },
@@ -182,6 +192,7 @@ export const sentencesData: Record<number, Sentence> = {
     profileIconImage: 'path/to/image8.png',
     evaluationGoodCount: 13,
     evaluationStayCount: 5,
+    userEvaluation: null,
     createdAt: '2024-01-09T00:00:00Z',
     updatedAt: '2024-01-09T00:00:00Z',
   },
@@ -194,6 +205,7 @@ export const sentencesData: Record<number, Sentence> = {
     profileIconImage: 'path/to/image9.png',
     evaluationGoodCount: 16,
     evaluationStayCount: 2,
+    userEvaluation: null,
     createdAt: '2024-01-10T00:00:00Z',
     updatedAt: '2024-01-10T00:00:00Z',
   },
@@ -206,6 +218,7 @@ export const sentencesData: Record<number, Sentence> = {
     profileIconImage: 'path/to/image10.png',
     evaluationGoodCount: 25,
     evaluationStayCount: 4,
+    userEvaluation: null,
     createdAt: '2024-01-11T00:00:00Z',
     updatedAt: '2024-01-11T00:00:00Z',
   },
@@ -218,6 +231,7 @@ export const sentencesData: Record<number, Sentence> = {
     profileIconImage: 'path/to/image11.png',
     evaluationGoodCount: 19,
     evaluationStayCount: 7,
+    userEvaluation: null,
     createdAt: '2024-01-12T00:00:00Z',
     updatedAt: '2024-01-12T00:00:00Z',
   },
@@ -230,6 +244,7 @@ export const sentencesData: Record<number, Sentence> = {
     profileIconImage: 'path/to/image12.png',
     evaluationGoodCount: 8,
     evaluationStayCount: 9,
+    userEvaluation: null,
     createdAt: '2024-01-13T00:00:00Z',
     updatedAt: '2024-01-13T00:00:00Z',
   },
@@ -242,6 +257,7 @@ export const sentencesData: Record<number, Sentence> = {
     profileIconImage: 'path/to/image13.png',
     evaluationGoodCount: 21,
     evaluationStayCount: 3,
+    userEvaluation: null,
     createdAt: '2024-01-14T00:00:00Z',
     updatedAt: '2024-01-14T00:00:00Z',
   },
@@ -254,6 +270,7 @@ export const sentencesData: Record<number, Sentence> = {
     profileIconImage: 'path/to/image14.png',
     evaluationGoodCount: 31,
     evaluationStayCount: 2,
+    userEvaluation: null,
     createdAt: '2024-01-15T00:00:00Z',
     updatedAt: '2024-01-15T00:00:00Z',
   },
@@ -579,11 +596,12 @@ export const buildInitialData = (sentenceId: number) => {
 
 // モックデータの更新
 // sentenceIdを引数で受け取る関数に変更
-export const getMockContainerData = (sentenceId: number) => buildInitialData(sentenceId) || {
-  main: [],
-  parent: [],
-  children: [],
-};
+export const getMockContainerData = (sentenceId: number) =>
+  buildInitialData(sentenceId) || {
+    main: [],
+    parent: [],
+    children: [],
+  };
 
 const emptySentence: Sentence = {
   sentenceId: 0,
@@ -593,6 +611,7 @@ const emptySentence: Sentence = {
   profileIconImage: '',
   evaluationGoodCount: 0,
   evaluationStayCount: 0,
+  userEvaluation: null,
   createdAt: '1970-01-01T00:00:00Z',
   updatedAt: '1970-01-01T00:00:00Z',
 };

--- a/src/features/NovelView/mocks/data.ts
+++ b/src/features/NovelView/mocks/data.ts
@@ -73,15 +73,7 @@ export const mockNovelProps = {
   main: mockMainPanel,
 };
 
-// 初期読み込み用のセンテンスID設定
-// The initial sentence ID is set to 5 by default, as it represents the center of a more complex structure in the mock data.
-// You can override this value by setting the environment variable INITIAL_SENTENCE_ID.
-export const INITIAL_SENTENCE_ID =
-  typeof process !== 'undefined' &&
-  process.env &&
-  process.env.INITIAL_SENTENCE_ID
-    ? Number(process.env.INITIAL_SENTENCE_ID)
-    : 5;
+
 
 // センテンスの一意のIDを持つデータ
 
@@ -586,7 +578,8 @@ export const buildInitialData = (sentenceId: number) => {
 };
 
 // モックデータの更新
-export const mockContainerData = buildInitialData(INITIAL_SENTENCE_ID) || {
+// sentenceIdを引数で受け取る関数に変更
+export const getMockContainerData = (sentenceId: number) => buildInitialData(sentenceId) || {
   main: [],
   parent: [],
   children: [],
@@ -604,43 +597,44 @@ const emptySentence: Sentence = {
   updatedAt: '1970-01-01T00:00:00Z',
 };
 
-// 初期サンプル文データ（OpenAPI仕様に準拠）
-// OpenAPI仕様のSentence型に完全に準拠していることを保証
-export const initialSampleSentence: Sentence = {
-  sentenceId:
-    sentencesData[INITIAL_SENTENCE_ID]?.sentenceId ??
-    sentencesData[1]?.sentenceId ??
-    emptySentence.sentenceId,
-  sentence:
-    sentencesData[INITIAL_SENTENCE_ID]?.sentence ??
-    sentencesData[1]?.sentence ??
-    emptySentence.sentence,
-  sentenceUserId:
-    sentencesData[INITIAL_SENTENCE_ID]?.sentenceUserId ??
-    sentencesData[1]?.sentenceUserId ??
-    emptySentence.sentenceUserId,
-  sentencePenName:
-    sentencesData[INITIAL_SENTENCE_ID]?.sentencePenName ??
-    sentencesData[1]?.sentencePenName ??
-    emptySentence.sentencePenName,
-  profileIconImage:
-    sentencesData[INITIAL_SENTENCE_ID]?.profileIconImage ??
-    sentencesData[1]?.profileIconImage ??
-    emptySentence.profileIconImage,
-  evaluationGoodCount:
-    sentencesData[INITIAL_SENTENCE_ID]?.evaluationGoodCount ??
-    sentencesData[1]?.evaluationGoodCount ??
-    emptySentence.evaluationGoodCount,
-  evaluationStayCount:
-    sentencesData[INITIAL_SENTENCE_ID]?.evaluationStayCount ??
-    sentencesData[1]?.evaluationStayCount ??
-    emptySentence.evaluationStayCount,
-  createdAt:
-    sentencesData[INITIAL_SENTENCE_ID]?.createdAt ??
-    sentencesData[1]?.createdAt ??
-    emptySentence.createdAt,
-  updatedAt:
-    sentencesData[INITIAL_SENTENCE_ID]?.updatedAt ??
-    sentencesData[1]?.updatedAt ??
-    emptySentence.updatedAt,
+// sentenceIdを引数で受け取る関数に変更
+export const getInitialSampleSentence = (sentenceId: number): Sentence => {
+  return {
+    sentenceId:
+      sentencesData[sentenceId]?.sentenceId ??
+      sentencesData[1]?.sentenceId ??
+      emptySentence.sentenceId,
+    sentence:
+      sentencesData[sentenceId]?.sentence ??
+      sentencesData[1]?.sentence ??
+      emptySentence.sentence,
+    sentenceUserId:
+      sentencesData[sentenceId]?.sentenceUserId ??
+      sentencesData[1]?.sentenceUserId ??
+      emptySentence.sentenceUserId,
+    sentencePenName:
+      sentencesData[sentenceId]?.sentencePenName ??
+      sentencesData[1]?.sentencePenName ??
+      emptySentence.sentencePenName,
+    profileIconImage:
+      sentencesData[sentenceId]?.profileIconImage ??
+      sentencesData[1]?.profileIconImage ??
+      emptySentence.profileIconImage,
+    evaluationGoodCount:
+      sentencesData[sentenceId]?.evaluationGoodCount ??
+      sentencesData[1]?.evaluationGoodCount ??
+      emptySentence.evaluationGoodCount,
+    evaluationStayCount:
+      sentencesData[sentenceId]?.evaluationStayCount ??
+      sentencesData[1]?.evaluationStayCount ??
+      emptySentence.evaluationStayCount,
+    createdAt:
+      sentencesData[sentenceId]?.createdAt ??
+      sentencesData[1]?.createdAt ??
+      emptySentence.createdAt,
+    updatedAt:
+      sentencesData[sentenceId]?.updatedAt ??
+      sentencesData[1]?.updatedAt ??
+      emptySentence.updatedAt,
+  };
 };

--- a/src/features/NovelView/mocks/handlers.ts
+++ b/src/features/NovelView/mocks/handlers.ts
@@ -5,7 +5,11 @@ import {
   Sentence,
   ViewMeUser,
 } from '../../../api/api';
-import { sentencesData, getMockContainerData, getParallelSentences } from './data';
+import {
+  sentencesData,
+  getMockContainerData,
+  getParallelSentences,
+} from './data';
 
 const apiBaseUrl = import.meta.env.VITE_API_BASE_URL;
 

--- a/src/features/NovelView/mocks/handlers.ts
+++ b/src/features/NovelView/mocks/handlers.ts
@@ -5,14 +5,15 @@ import {
   Sentence,
   ViewMeUser,
 } from '../../../api/api';
-import { initialSampleSentence } from './data';
+import { sentencesData, getMockContainerData, getParallelSentences } from './data';
 
 const apiBaseUrl = import.meta.env.VITE_API_BASE_URL;
 
 // サーバー側で一元管理する文データ
-let sentences: Sentence[] = [{ ...initialSampleSentence }];
+// 初期値は持たず、外部から得るsentenceIdでのみデータを返す
+let sentences: Sentence[] = [];
 
-let nextSentenceId = (initialSampleSentence.sentenceId ?? 0) + 1;
+let nextSentenceId = Math.max(...Object.keys(sentencesData).map(Number)) + 1;
 
 // モックユーザー情報
 const mockUser: ViewMeUser = {
@@ -50,42 +51,29 @@ export const novelViewHandlers = [
   // 文を取得するハンドラー（GET sentenceId指定）
   http.get(`${apiBaseUrl}/sentences/:sentenceId`, ({ params }) => {
     const { sentenceId } = params;
-    const found = sentences.find((s) => s.sentenceId === Number(sentenceId));
-
-    if (found) {
-      // childrenデータを追加（モックデータ）
-      const response = {
-        ...found,
-        children: [
-          {
-            sentenceId: (found.sentenceId || 0) + 100,
-            sentence:
-              'これは子投稿のサンプルテキストです。評価後に表示されます。',
-            sentenceUserId: 2,
-            sentencePenName: '子投稿ユーザー',
-            profileIconImage: '/path/to/child-avatar.jpg',
-            evaluationGoodCount: 3,
-            evaluationStayCount: 1,
-            createdAt: new Date().toISOString(),
-            updatedAt: new Date().toISOString(),
-          },
-          {
-            sentenceId: (found.sentenceId || 0) + 101,
-            sentence: 'もう一つの子投稿です。複数の続きを読むことができます。',
-            sentenceUserId: 3,
-            sentencePenName: '別のユーザー',
-            profileIconImage: '/path/to/another-avatar.jpg',
-            evaluationGoodCount: 5,
-            evaluationStayCount: 2,
-            createdAt: new Date().toISOString(),
-            updatedAt: new Date().toISOString(),
-          },
-        ],
-      };
-      return HttpResponse.json(response);
+    if (!sentenceId) {
+      return new HttpResponse('sentenceId is required', { status: 400 });
     }
-
-    return HttpResponse.json(sentences[0]);
+    const id = Number(sentenceId);
+    if (isNaN(id)) {
+      return new HttpResponse('sentenceId must be a number', { status: 400 });
+    }
+    // main, parent, children, parallelsを取得（mainがなければ404）
+    const container = getMockContainerData(id);
+    if (!container.main || !container.main[0]) {
+      return new HttpResponse('Not found', { status: 404 });
+    }
+    const main = container.main[0];
+    const parent = container.parent[0] || null;
+    const children = container.children || [];
+    const parallels = getParallelSentences(id) || [];
+    const response = {
+      main,
+      parent,
+      children,
+      parallels,
+    };
+    return HttpResponse.json(response);
   }),
 
   // 評価APIハンドラー

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,11 +6,11 @@ import { BrowserRouter } from 'react-router';
 
 async function enableMocking() {
   // ここをコメントアウトするとMSWが無効になる
-  // if (!import.meta.env.PROD) {
-  //   const { worker } = await import('../src/mock/browser');
-  //   worker.start();
-  // }
-  // return Promise.resolve();
+  if (!import.meta.env.PROD) {
+    const { worker } = await import('../src/mock/browser');
+    worker.start();
+  }
+  return Promise.resolve();
 }
 
 enableMocking().then(() => {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import './index.css';
 import { BrowserRouter } from 'react-router';
 
 async function enableMocking() {
+  // ここをコメントアウトするとMSWが無効になる
   if (!import.meta.env.PROD) {
     const { worker } = await import('../src/mock/browser');
     worker.start();

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,11 +6,11 @@ import { BrowserRouter } from 'react-router';
 
 async function enableMocking() {
   // ここをコメントアウトするとMSWが無効になる
-  if (!import.meta.env.PROD) {
-    const { worker } = await import('../src/mock/browser');
-    worker.start();
-  }
-  return Promise.resolve();
+  // if (!import.meta.env.PROD) {
+  //   const { worker } = await import('../src/mock/browser');
+  //   worker.start();
+  // }
+  // return Promise.resolve();
 }
 
 enableMocking().then(() => {


### PR DESCRIPTION
## JIRAチケットURL
- 小説投稿閲覧
  - https://techno-kuro-novel.atlassian.net/browse/CNV-89
- 投稿評価機能
  - https://techno-kuro-novel.atlassian.net/browse/CNV-92
- /novels/{titleId}のレスポンスにfirstSentencesIdパラメータを追加
  - https://techno-kuro-novel.atlassian.net/browse/CNV-232
- /sentences/{sentenceId}のレスポンスにログインユーザーの投稿評価状態も追加する
  - https://techno-kuro-novel.atlassian.net/browse/CNV-233
- /evaluationsにも投稿評価状態を追加する
  - https://techno-kuro-novel.atlassian.net/browse/CNV-234

---
## 実装内容

- 投稿閲覧画面のurlを`/[novelId]/[sentenceId]`にする
  - 投稿閲覧画面のリンクボタンのurlを`/[novelId]/[sentenceId]`にする
  - 小説概要情報API`/novels/[titleId]`のレスポンスから`firstSentencesId`を取得する
  - urlの`[sentenceId]`に`firstSentencesId`を渡す
- 投稿閲覧画面で投稿情報が表示されるようにする
  - urlから`sentenceid`を取得して`/sentences/[sentenceId]`APIを叩く
  - レスポンスを投稿閲覧画面に表示する
- 投稿評価によってボタンのカウント数、アクティブ色が反映される
  - 投稿閲覧情報API`/sentences/{sentenceId}`のレスポンスから`userEvaluation`を取得する
    - `userEvaluation`に該当するボタンの色をアクティブ色にする
  - 投稿評価API`/evaluations`のレスポンスからも`userEvaluation`を取得
    - 該当するボタンの色をアクティブ色、該当しないボタンは色を解除
    - カウント数の増減も反映する
- その他
  - openapi定義追加
    - `/novels/[titleId]`のレスポンスに`firstSentencesId`を追加
    - `/sentences/[sentenceId]`のレスポンスに`userEvaluation`を追加
    - `/evaluations`のレスポンスに`userEvaluation`を追加
  - ボタンのコンポーネント名がわかりにくかったため変更
    - ThumbUpButton → GoodButton
    - NextPlanButton → StayButton
  - ボタンのクリックアクションがGoodは親コンポーネント、Stayはボタンコンポーネントにあったのを親側に統合する
  - NovelViewContainerの中に重複処理があったため関数に切り出して共通化する
  
### 機能要件

このセクションでは、以下URL参照先（機能要件）の記載を引用し、どの要件を満たすための実装をしたのかを記載します。
https://techno-kuro-novel.atlassian.net/wiki/spaces/Conovel/pages/3145744
なお、上記URLに含まれない実装をしている場合は、適宜参照先URLを付して、記載を引用して記載してください。
必ず製造タスクの根拠を示してください。

　例　テーブル定義Miroやその他資料

- 機能要件1
- 機能要件2
- 機能要件3

また、上記要件資料を参照し、漏れがないことを確認したら、チェックします。

[] 要件漏れがないことを確認済み
[] 一部懸念あり

### 非機能要件

このセクションでは、以下URL参照先（非機能要件）の記載を引用し、どの要件を満たすための実装をしたのかを記載します。
https://techno-kuro-novel.atlassian.net/wiki/spaces/Conovel/pages/1376286/_PJ
なお、上記URLに含まれない実装をしている場合は、適宜参照先URLを付して、記載を引用して記載してください。

- 非機能要件1
- 非機能要件2
- 非機能要件3

以下非機能要件を遵守すべき事項を確認しチェック
[] CORS制約
[] XSS防止
[] CSRF防止
[] 認証中トークン
[] 広告枠

---

## 自身で確認した動作のエビデンス（スクショ等）

### 動作確認エビデンス1

詳細画面から「本文へ」を押すと
<img width="336" height="594" alt="スクリーンショット 2025-11-13 9 07 29" src="https://github.com/user-attachments/assets/1ce423a5-4561-4d9f-a22c-50cbfccc6a56" />

投稿閲覧情報のレスポンスが画面に表示されている
（urlは`/[novelId]/[sentenceId]`になっている）
<img width="337" height="589" alt="スクリーンショット 2025-11-13 9 26 01" src="https://github.com/user-attachments/assets/282c1d5a-19bf-4ee5-9b1a-8dec491dac33" />

Goodボタンを押すとGoodがアクティブ色になり、カウントが1増える
子投稿のボカシが消える
<img width="350" height="596" alt="スクリーンショット 2025-11-13 9 26 08" src="https://github.com/user-attachments/assets/7ca8593e-19fc-4977-9bb7-0339c8b61320" />

Stayボタンを押すとStayがアクティブ色になりカウントが1増える
Goodは非アクティブになりカウントがが1減る
<img width="335" height="595" alt="スクリーンショット 2025-11-13 9 26 14" src="https://github.com/user-attachments/assets/7797123b-ac84-4fa8-9f37-b16dcde8a108" />

### 動作確認エビデンス2

【懸念点】
以前、@Yuya757に共有された正しいUIの動きが完全には再現されていないように思う

手打ちでurlを/1/2にした画面
- 親投稿の表示枠がおかしい？
- 兄弟投稿に遷移するアイコンはレスポンスにpararellがあれば有効なのでOK
- 親投稿への遷移もOK
- 子投稿は押下しても遷移できない
<img width="342" height="601" alt="スクリーンショット 2025-11-13 9 46 17" src="https://github.com/user-attachments/assets/fb4912b5-b1f0-4f91-8905-440ca1bdccb9" />

手打ちでurlを/1/3にした画面
- mainが評価済みなのに子投稿はボカシのまま
<img width="344" height="604" alt="スクリーンショット 2025-11-13 9 35 19" src="https://github.com/user-attachments/assets/789c025e-2be5-4129-8957-78e421a43463" />

- この状態で子投稿に遷移しようとすると「メインパネルで評価を行ってから、続きの投稿をクリックしてください」というポップアップが出るがヘッダーの下になりよく見えない
（評価済みならボカシもなしで遷移できるようにしたい）
<img width="346" height="577" alt="スクリーンショット 2025-11-13 9 41 48" src="https://github.com/user-attachments/assets/2136adfe-7825-4b75-b15c-84fac773fbf0" />

- 評価し直すとボカシは消えるが子投稿を押下しても子投稿がmainになった画面に遷移しない（ポップアップも出ない）
<img width="339" height="587" alt="スクリーンショット 2025-11-13 9 35 28" src="https://github.com/user-attachments/assets/b3789546-4444-41e2-bbe5-835089037b1a" />

- ログアウト状態で投稿本文を見ようとすると空の表示になる
<img width="342" height="590" alt="スクリーンショット 2025-11-13 9 49 46" src="https://github.com/user-attachments/assets/37365769-cb95-49c3-ad98-b71266f25438" />


---

## 結合テスト・受入テストに持ち越すテスト項目（必ず1つ以上作成）
本PullReqで洗い出し記載して、Mergeしたら、以下に整理転記する
https://techno-kuro-novel.atlassian.net/wiki/spaces/Conovel/pages/38567991

### テスト要求1

### テスト要求2

### テスト要求3
